### PR TITLE
Fix metadata output paths

### DIFF
--- a/code/exaspim_flatfield_correction/utils/metadata_utils.py
+++ b/code/exaspim_flatfield_correction/utils/metadata_utils.py
@@ -89,7 +89,7 @@ def save_metadata(
         f.write(process_json)
 
     input_metadata_path = get_parent_s3_path(get_parent_s3_path(tile_path))
-    output_metadata_path = get_parent_s3_path(out_path)
+    output_metadata_path = get_parent_s3_path(get_parent_s3_path(out_path))
     metadata_json_path = str(
         Path(results_dir)
         / f"metadata_paths_{Path(out_path).parent.name}_{tile_name}.json"


### PR DESCRIPTION
Metadata files should be copied to the top-level processed asset folder, not the flatfield_correction/ folder.
