### PR TITLE
Feat: round corrected float32 array before uint16 cast

### DIFF
--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -653,7 +653,7 @@ def flatfield_fitting(
     weights = mask_artifacts.probability_volume
 
     global_val = weighted_percentile(
-        low_res.astype(np.uint16),
+        low_res.round().astype(np.uint16),
         mask,
         profile_percentile,
         weights=weights,
@@ -929,7 +929,7 @@ def process_tile(
             else:
                 corrected = full_res
 
-            corrected = corrected.astype(np.uint16)
+            corrected = corrected.round().astype(np.uint16)
             _LOGGER.info(f"Corrected array dtype: {corrected.dtype}")
 
             t0 = time.time()

--- a/environment/postInstall
+++ b/environment/postInstall
@@ -9,7 +9,7 @@ conda activate correction
 
 git clone https://github.com/AllenNeuralDynamics/exaspim-flatfield-correction.git
 cd exaspim-flatfield-correction
-git checkout 72d8eb11465e6bb611c6e8eca8a8d0929d86b848
+git checkout 7b2b51e0d14364ca57ae5bde2a7e142c691f7f3e
 pip install .
 
 pip install "aind-data-schema==2.6.0"


### PR DESCRIPTION
Recent datasets have very low tissue-level SNR, leading to background subtracted data hovering near-zero. We can round before casting to prevent values > 0.5 being squashed to zero in the output
