### PR TITLE
Feat: map low-res background slice indices to target resolution

### DIFF
--- a/code/exaspim_flatfield_correction/__init__.py
+++ b/code/exaspim_flatfield_correction/__init__.py
@@ -1,3 +1,3 @@
 """Top-level package for exaspim flatfield correction."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/code/exaspim_flatfield_correction/background.py
+++ b/code/exaspim_flatfield_correction/background.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import dask.array as da
 import numpy as np
@@ -87,6 +88,181 @@ def estimate_bkg(
     mu_final = np.median(im, axis=0).astype(np.float32)  # (y, x)
 
     return mu_final, retained_indices.astype(np.int64, copy=False)
+
+
+def _z_scale_and_translation(
+    transformations: dict[str, Any] | None,
+) -> tuple[float, float] | None:
+    """Extract the Z scale/translation from OME-Zarr transformations."""
+
+    if not transformations:
+        return None
+
+    scale = transformations.get("scale")
+    if scale is None or len(scale) < 3:
+        return None
+
+    translation = transformations.get("translation")
+    z_translation = 0.0
+    if translation is not None and len(translation) >= 3:
+        z_translation = float(translation[-3])
+
+    z_scale = float(scale[-3])
+    if not np.isfinite(z_scale) or z_scale <= 0:
+        return None
+    if not np.isfinite(z_translation):
+        return None
+
+    return z_scale, z_translation
+
+
+def map_slice_indices_to_target(
+    source_indices: np.ndarray,
+    source_shape: tuple[int, ...],
+    target_shape: tuple[int, ...],
+    source_transformations: dict[str, Any] | None = None,
+    target_transformations: dict[str, Any] | None = None,
+) -> np.ndarray:
+    """Map source Z slices to all target Z planes covered by those slices.
+
+    The returned indices are in the target array coordinate system. When both
+    source and target OME-Zarr scale metadata are present, mapping is performed
+    in physical/world coordinates. Otherwise, it falls back to the ratio of
+    target and source Z sizes.
+    """
+
+    source_indices = np.asarray(source_indices, dtype=np.int64)
+    if source_indices.ndim != 1:
+        raise ValueError("source_indices must be a 1D array.")
+    if len(source_shape) != 3 or len(target_shape) != 3:
+        raise ValueError(
+            "source_shape and target_shape must be 3D ZYX shapes."
+        )
+
+    source_z = int(source_shape[0])
+    target_z = int(target_shape[0])
+    if source_z <= 0 or target_z <= 0:
+        raise ValueError("source and target Z dimensions must be positive.")
+    if np.any(source_indices < 0) or np.any(source_indices >= source_z):
+        raise ValueError("source_indices contain slices outside source_shape.")
+
+    source_transform = _z_scale_and_translation(source_transformations)
+    target_transform = _z_scale_and_translation(target_transformations)
+    use_metadata = (
+        source_transform is not None and target_transform is not None
+    )
+
+    if use_metadata:
+        source_scale, source_translation = source_transform
+        target_scale, target_translation = target_transform
+    else:
+        raise ValueError(
+            "OME-Zarr scale/translation metadata unavailable for background "
+            "slice mapping; falling back to shape-ratio mapping."
+        )
+
+    mapped_indices: list[int] = []
+    eps = 1e-9
+    for source_index in source_indices:
+        source_start = source_translation + float(source_index) * source_scale
+        source_stop = (
+            source_translation + float(source_index + 1) * source_scale
+        )
+
+        start_index = int(
+            np.floor((source_start - target_translation) / target_scale + eps)
+        )
+        stop_index = int(
+            np.ceil((source_stop - target_translation) / target_scale - eps)
+        )
+
+        start_index = max(0, start_index)
+        stop_index = min(target_z, stop_index)
+        if stop_index > start_index:
+            mapped_indices.extend(range(start_index, stop_index))
+
+    return np.unique(np.asarray(mapped_indices, dtype=np.int64))
+
+
+def _rechunk_for_plane_median(
+    im: da.Array,
+    max_spatial_chunk: int,
+) -> da.Array:
+    """Use one Z chunk and capped spatial chunks for a plane-wise median."""
+
+    spatial_chunks = []
+    for axis in (1, 2):
+        existing = (
+            int(im.chunks[axis][0]) if im.chunks else int(im.shape[axis])
+        )
+        spatial_chunks.append(
+            max(1, min(int(im.shape[axis]), existing, max_spatial_chunk))
+        )
+
+    return im.rechunk((int(im.shape[0]), *spatial_chunks))
+
+
+def estimate_bkg_from_mapped_slices(
+    target_im: da.Array,
+    source_slice_indices: np.ndarray,
+    source_shape: tuple[int, ...],
+    source_transformations: dict[str, Any] | None = None,
+    target_transformations: dict[str, Any] | None = None,
+    max_spatial_chunk: int = 512,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Estimate a target-resolution background from mapped source slices.
+
+    Parameters
+    ----------
+    target_im : dask.array.Array, shape (z, y, x)
+        Target-resolution image volume from which the final background image
+        should be constructed.
+    source_slice_indices : np.ndarray
+        Background-dominant source-resolution Z slice indices.
+    source_shape : tuple[int, ...]
+        Shape of the source-resolution volume used to select the slices.
+    source_transformations : dict or None, default=None
+        OME-Zarr scale/translation metadata for the selector volume.
+    target_transformations : dict or None, default=None
+        OME-Zarr scale/translation metadata for ``target_im``.
+    max_spatial_chunk : int, default=512
+        Maximum Y/X chunk edge length to use when computing the Dask median.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        The target-resolution 2D median background and the mapped target Z
+        indices used to compute it.
+    """
+
+    if target_im.ndim != 3:
+        raise ValueError("target_im must be a 3D array with shape (z, y, x).")
+    if max_spatial_chunk <= 0:
+        raise ValueError("max_spatial_chunk must be positive.")
+
+    target_indices = map_slice_indices_to_target(
+        source_slice_indices,
+        source_shape,
+        target_im.shape,
+        source_transformations=source_transformations,
+        target_transformations=target_transformations,
+    )
+    if target_indices.size == 0:
+        raise ValueError(
+            "Background source slices did not map to any target Z planes."
+        )
+
+    _LOGGER.info(
+        "Mapped %s source background slices to %s target planes.",
+        len(source_slice_indices),
+        len(target_indices),
+    )
+
+    selected = da.take(target_im.astype(np.float32), target_indices, axis=0)
+    selected = _rechunk_for_plane_median(selected, max_spatial_chunk)
+    bkg = da.median(selected, axis=0).astype(np.float32).compute()
+
+    return bkg.astype(np.float32, copy=False), target_indices
 
 
 def subtract_bkg(im: da.Array, bkg_da: da.Array) -> da.Array:

--- a/code/exaspim_flatfield_correction/background.py
+++ b/code/exaspim_flatfield_correction/background.py
@@ -158,7 +158,7 @@ def map_slice_indices_to_target(
     else:
         raise ValueError(
             "OME-Zarr scale/translation metadata unavailable for background "
-            "slice mapping; falling back to shape-ratio mapping."
+            "slice mapping."
         )
 
     mapped_indices: list[int] = []

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -19,7 +19,11 @@ from dask.distributed import performance_report
 from dask_image.ndfilters import gaussian_filter as gaussian_filter_dask
 from scipy.ndimage import binary_fill_holes
 
-from exaspim_flatfield_correction.background import estimate_bkg, subtract_bkg
+from exaspim_flatfield_correction.background import (
+    estimate_bkg,
+    estimate_bkg_from_mapped_slices,
+    subtract_bkg,
+)
 from exaspim_flatfield_correction.basic import fit_basic, transform_basic
 from exaspim_flatfield_correction.config import (
     FittingConfig,
@@ -209,6 +213,7 @@ def background_subtraction(
     is_binned_channel: bool = False,
     use_reference_bkg: bool = False,
     background_smoothing_sigma: float = 1.0,
+    target_resolution: str = "0",
 ) -> tuple[da.Array, np.ndarray, np.ndarray | None]:
     """Remove background estimates from the full-resolution volume.
 
@@ -227,19 +232,31 @@ def background_subtraction(
         it from the data.
     background_smoothing_sigma : float, default=1.0
         Gaussian smoothing sigma applied before background estimation. Set to
-        0 to disable smoothing.
+        0 to disable smoothing. Smoothing is only used to select background
+        slices; estimated subtraction backgrounds are built from raw target
+        resolution planes.
+    target_resolution : str, default="0"
+        Resolution key of ``full_res`` within ``z``. Used to map background
+        slice selections from the estimation resolution to the corrected
+        target resolution.
 
     Returns
     -------
     tuple
-        ``(full_res_corrected, background_image, background_slice_indices)``
-        where ``background_slice_indices`` may be ``None`` if no probabilistic
-        model is required.
+        ``(full_res_corrected, background_image, background_slice_indices)``.
+        ``background_image`` is in the target resolution, while
+        ``background_slice_indices`` remain in the estimation-resolution
+        coordinate system. ``background_slice_indices`` may be ``None`` when
+        a reference background is used.
     """
     if use_reference_bkg:
         bkg_path = get_bkg_path(tile_path)
         bkg = read_bkg_image(bkg_path).astype(np.float32)
         bkg_slice_indices = None
+        if bkg.shape != full_res.shape[1:]:
+            bkg = resize(bkg, full_res.shape[1:]).astype(
+                np.float32, copy=False
+            )
     else:
         bkg_res = "0" if is_binned_channel else "3"
         _LOGGER.info(f"Using resolution {bkg_res} for background estimation")
@@ -248,17 +265,33 @@ def background_subtraction(
             background_smoothing_sigma,
         )
         low_res = da.from_zarr(z[bkg_res]).squeeze().astype(np.float32)
+        low_res_shape = tuple(int(dim) for dim in low_res.shape)
         if background_smoothing_sigma > 0:
             low_res = gaussian_filter_dask(
                 low_res, sigma=background_smoothing_sigma
             )
-        bkg, bkg_slice_indices = estimate_bkg(low_res.compute())
+        _, bkg_slice_indices = estimate_bkg(low_res.compute())
+
+        source_transformations = parse_ome_zarr_transformations(z, bkg_res)
+        target_transformations = parse_ome_zarr_transformations(
+            z, target_resolution
+        )
+        bkg, target_slice_indices = estimate_bkg_from_mapped_slices(
+            full_res,
+            bkg_slice_indices,
+            low_res_shape,
+            source_transformations=source_transformations,
+            target_transformations=target_transformations,
+        )
+        _LOGGER.info(
+            "Computed target-resolution background from target slices %s..%s",
+            int(target_slice_indices[0]),
+            int(target_slice_indices[-1]),
+        )
 
     full_res = subtract_bkg(
         full_res,
-        da.from_array(
-            resize(bkg, full_res.shape[1:]), chunks=full_res.chunksize[1:]
-        ),
+        da.from_array(bkg, chunks=full_res.chunksize[1:]),
     )
     return full_res, bkg, bkg_slice_indices
 
@@ -890,6 +923,7 @@ def process_tile(
                     is_binned_channel,
                     use_reference_bkg=args.use_reference_bkg,
                     background_smoothing_sigma=args.background_smoothing_sigma,
+                    target_resolution=resolution,
                 )
 
             axis_fits = None

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -802,7 +802,7 @@ def save_method_outputs(
     if not save_outputs or results_dir is None:
         return
 
-    # Always try to save background-derived outputs if provided
+    # Save background-derived outputs independently when provided.
     try:
         if bkg_slice_indices is not None:
             indices_out = os.path.join(
@@ -813,7 +813,7 @@ def save_method_outputs(
                     np.asarray(bkg_slice_indices, dtype=np.int64).tolist(),
                     handle,
                 )
-        elif bkg is not None:
+        if bkg is not None:
             tifffile.imwrite(
                 os.path.join(results_dir, f"{tile_name}_bkg.tif"),
                 np.asarray(bkg, dtype=np.float32),

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -2,7 +2,9 @@ import argparse
 import json
 import logging
 import os
+import shutil
 import time
+import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -223,12 +225,14 @@ def background_subtraction(
     tile_path: str,
     full_res: da.Array,
     z: zarr.hierarchy.Group,
+    results_dir: str | None = None,
+    tile_name: str | None = None,
     is_binned_channel: bool = False,
     use_reference_bkg: bool = False,
     background_smoothing_sigma: float = 1.0,
     background_final_smoothing_sigma: float = 0.0,
     target_resolution: str = "0",
-) -> tuple[da.Array, np.ndarray, np.ndarray | None]:
+) -> tuple[da.Array, np.ndarray, np.ndarray | None, Path | None]:
     """Remove background estimates from the full-resolution volume.
 
     Parameters
@@ -239,6 +243,10 @@ def background_subtraction(
         Full-resolution image volume to correct (modified lazily).
     z : zarr.hierarchy.Group
         Open Zarr hierarchy for the tile.
+    results_dir : str or None, default=None
+        Directory where the temporary background Zarr cache should be written.
+    tile_name : str or None, default=None
+        Tile identifier used to create unique Dask names and cache paths.
     is_binned_channel : bool, default=False
         Flag indicating whether the tile represents the binned channel.
     use_reference_bkg : bool, default=False
@@ -261,16 +269,25 @@ def background_subtraction(
     Returns
     -------
     tuple
-        ``(full_res_corrected, background_image, background_slice_indices)``.
-        ``background_image`` is in the target resolution, while
-        ``background_slice_indices`` remain in the estimation-resolution
-        coordinate system. ``background_slice_indices`` may be ``None`` when
-        a reference background is used.
+        ``(full_res_corrected, background_image, background_slice_indices,
+        background_cache_path)``. ``background_image`` is in the target
+        resolution, while ``background_slice_indices`` remain in the
+        estimation-resolution coordinate system. ``background_slice_indices``
+        may be ``None`` when a reference background is used.
     """
+    if results_dir is None:
+        raise ValueError(
+            "results_dir is required for background cache writes."
+        )
+    if tile_name is None:
+        tile_name = Path(tile_path).name
     if background_final_smoothing_sigma < 0:
         raise ValueError(
             "background_final_smoothing_sigma must be non-negative."
         )
+
+    dask_name_token = uuid.uuid4().hex
+    safe_tile_name = _safe_dask_name(tile_name)
 
     if use_reference_bkg:
         bkg_path = get_bkg_path(tile_path)
@@ -287,7 +304,10 @@ def background_subtraction(
             "Background estimation smoothing sigma: %s",
             background_smoothing_sigma,
         )
-        low_res = da.from_zarr(z[bkg_res]).squeeze().astype(np.float32)
+        low_res = da.from_zarr(
+            z[bkg_res],
+            name=f"bkg-selector-{safe_tile_name}-{bkg_res}-{dask_name_token}",
+        ).squeeze().astype(np.float32)
         low_res_shape = tuple(int(dim) for dim in low_res.shape)
         if background_smoothing_sigma > 0:
             low_res = gaussian_filter_dask(
@@ -316,20 +336,95 @@ def background_subtraction(
         "Final background smoothing sigma: %s",
         background_final_smoothing_sigma,
     )
-    bkg_da = da.from_array(bkg, chunks=full_res.chunksize[1:])
-    if background_final_smoothing_sigma > 0:
-        bkg_da = gaussian_filter_dask(
-            bkg_da,
-            sigma=background_final_smoothing_sigma,
-        ).astype(np.float32)
-        bkg = bkg_da.compute().astype(np.float32, copy=False)
-        bkg_da = da.from_array(bkg, chunks=full_res.chunksize[1:])
+    cache_dir = _background_cache_dir(results_dir, tile_name, dask_name_token)
+    spatial_chunks = chunks_2d(full_res)
+    try:
+        if background_final_smoothing_sigma > 0:
+            raw_cache_path = _write_background_cache(
+                bkg,
+                cache_dir / "raw.zarr",
+                spatial_chunks,
+            )
+            raw_bkg_da = _read_background_cache(
+                raw_cache_path,
+                name=f"bkg-cache-raw-{safe_tile_name}-{dask_name_token}",
+            )
+            blurred_bkg_da = gaussian_filter_dask(
+                raw_bkg_da,
+                sigma=background_final_smoothing_sigma,
+            ).astype(np.float32)
+            bkg = blurred_bkg_da.compute().astype(np.float32, copy=False)
+
+        final_cache_path = _write_background_cache(
+            bkg,
+            cache_dir / "final.zarr",
+            spatial_chunks,
+        )
+        bkg_da = _read_background_cache(
+            final_cache_path,
+            name=f"bkg-cache-final-{safe_tile_name}-{dask_name_token}",
+        )
+    except Exception:
+        cleanup_background_cache(cache_dir)
+        raise
 
     full_res = subtract_bkg(
         full_res,
         bkg_da,
     )
-    return full_res, bkg, bkg_slice_indices
+    return full_res, bkg, bkg_slice_indices, cache_dir
+
+
+def _safe_dask_name(value: str) -> str:
+    """Normalize user-facing identifiers for Dask graph layer names."""
+
+    return "".join(
+        char if char.isalnum() or char in "._-" else "_" for char in value
+    )
+
+
+def _background_cache_dir(
+    results_dir: str,
+    tile_name: str,
+    token: str,
+) -> Path:
+    """Create a unique local cache directory for a tile background image."""
+
+    cache_root = Path(results_dir) / "dask-temp" / "background-cache"
+    cache_dir = cache_root / f"{_safe_dask_name(tile_name)}_{token}"
+    cache_dir.mkdir(parents=True, exist_ok=False)
+    return cache_dir
+
+
+def _write_background_cache(
+    bkg: np.ndarray,
+    cache_path: Path,
+    chunks: tuple[int, ...],
+) -> Path:
+    """Write a 2D background image to a local chunked Zarr array."""
+
+    if cache_path.exists():
+        shutil.rmtree(cache_path)
+    zarr.save_array(
+        str(cache_path),
+        np.asarray(bkg, dtype=np.float32),
+        chunks=chunks,
+        compressor=blosc.Blosc(cname="zstd", clevel=1),
+    )
+    return cache_path
+
+
+def _read_background_cache(cache_path: Path, name: str) -> da.Array:
+    """Read a cached background image with a unique Dask graph name."""
+
+    return da.from_zarr(str(cache_path), name=name).astype(np.float32)
+
+
+def cleanup_background_cache(cache_path: Path | None) -> None:
+    """Remove a temporary background cache directory if it exists."""
+
+    if cache_path is not None:
+        shutil.rmtree(cache_path, ignore_errors=True)
 
 
 def flatfield_reference(full_res: da.Array, flatfield_path: str) -> da.Array:
@@ -925,6 +1020,7 @@ def process_tile(
     tile_name = Path(tile_path).name
     _LOGGER.info(f"Processing tile: {tile_name}")
     report_path = os.path.join(results_dir, f"dask-report_{tile_name}.html")
+    background_cache_path: Path | None = None
 
     with performance_report(filename=report_path):
         try:
@@ -945,17 +1041,30 @@ def process_tile(
                 f"Coordinate transformations: {coordinate_transformations}"
             )
 
-            full_res = da.from_zarr(z[resolution]).squeeze().astype(np.float32)
+            full_res = da.from_zarr(
+                z[resolution],
+                name=(
+                    f"input-{_safe_dask_name(tile_name)}-{resolution}-"
+                    f"{uuid.uuid4().hex}"
+                ),
+            ).squeeze().astype(np.float32)
             _LOGGER.info(f"Full resolution array shape: {full_res.shape}")
 
             bkg = None
             bkg_slice_indices = None
             if not args.skip_bkg_sub:
                 _LOGGER.info("Performing background subtraction")
-                full_res, bkg, bkg_slice_indices = background_subtraction(
+                (
+                    full_res,
+                    bkg,
+                    bkg_slice_indices,
+                    background_cache_path,
+                ) = background_subtraction(
                     tile_path,
                     full_res,
                     z,
+                    results_dir,
+                    tile_name,
                     is_binned_channel,
                     use_reference_bkg=args.use_reference_bkg,
                     background_smoothing_sigma=args.background_smoothing_sigma,
@@ -1060,6 +1169,8 @@ def process_tile(
                 f"Error processing tile {tile_name}: {exc}", exc_info=True
             )
             raise
+        finally:
+            cleanup_background_cache(background_cache_path)
 
     return mask_artifacts
 

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -187,6 +187,19 @@ def resolve_args(
         )
     merged_cli["background_smoothing_sigma"] = background_smoothing_sigma
 
+    background_final_smoothing_sigma = merged_cli.get(
+        "background_final_smoothing_sigma"
+    )
+    if background_final_smoothing_sigma is None:
+        background_final_smoothing_sigma = 0.0
+    if background_final_smoothing_sigma < 0:
+        raise ValueError(
+            "--background-final-smoothing-sigma must be non-negative."
+        )
+    merged_cli["background_final_smoothing_sigma"] = (
+        background_final_smoothing_sigma
+    )
+
     binned_channel = merged_cli.get("binned_channel")
     if binned_channel is None and merged_cli["is_binned"]:
         tile_name = Path(tile_paths[0]).name
@@ -213,6 +226,7 @@ def background_subtraction(
     is_binned_channel: bool = False,
     use_reference_bkg: bool = False,
     background_smoothing_sigma: float = 1.0,
+    background_final_smoothing_sigma: float = 0.0,
     target_resolution: str = "0",
 ) -> tuple[da.Array, np.ndarray, np.ndarray | None]:
     """Remove background estimates from the full-resolution volume.
@@ -235,6 +249,10 @@ def background_subtraction(
         0 to disable smoothing. Smoothing is only used to select background
         slices; estimated subtraction backgrounds are built from raw target
         resolution planes.
+    background_final_smoothing_sigma : float, default=0.0
+        Gaussian smoothing sigma applied to the final target-resolution 2D
+        background image before subtraction and artifact saving. Set to 0 to
+        disable final background smoothing.
     target_resolution : str, default="0"
         Resolution key of ``full_res`` within ``z``. Used to map background
         slice selections from the estimation resolution to the corrected
@@ -249,6 +267,11 @@ def background_subtraction(
         coordinate system. ``background_slice_indices`` may be ``None`` when
         a reference background is used.
     """
+    if background_final_smoothing_sigma < 0:
+        raise ValueError(
+            "background_final_smoothing_sigma must be non-negative."
+        )
+
     if use_reference_bkg:
         bkg_path = get_bkg_path(tile_path)
         bkg = read_bkg_image(bkg_path).astype(np.float32)
@@ -289,9 +312,22 @@ def background_subtraction(
             int(target_slice_indices[-1]),
         )
 
+    _LOGGER.info(
+        "Final background smoothing sigma: %s",
+        background_final_smoothing_sigma,
+    )
+    bkg_da = da.from_array(bkg, chunks=full_res.chunksize[1:])
+    if background_final_smoothing_sigma > 0:
+        bkg_da = gaussian_filter_dask(
+            bkg_da,
+            sigma=background_final_smoothing_sigma,
+        ).astype(np.float32)
+        bkg = bkg_da.compute().astype(np.float32, copy=False)
+        bkg_da = da.from_array(bkg, chunks=full_res.chunksize[1:])
+
     full_res = subtract_bkg(
         full_res,
-        da.from_array(bkg, chunks=full_res.chunksize[1:]),
+        bkg_da,
     )
     return full_res, bkg, bkg_slice_indices
 
@@ -923,6 +959,9 @@ def process_tile(
                     is_binned_channel,
                     use_reference_bkg=args.use_reference_bkg,
                     background_smoothing_sigma=args.background_smoothing_sigma,
+                    background_final_smoothing_sigma=(
+                        args.background_final_smoothing_sigma
+                    ),
                     target_resolution=resolution,
                 )
 
@@ -1143,6 +1182,16 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Gaussian smoothing sigma applied before background estimation. "
             "Set to 0 to disable smoothing."
+        ),
+    )
+    parser.add_argument(
+        "--background-final-smoothing-sigma",
+        type=float,
+        default=0.0,
+        help=(
+            "Gaussian smoothing sigma applied to the final 2D background "
+            "image before subtraction and saving. Set to 0 to disable final "
+            "background smoothing."
         ),
     )
     parser.add_argument(

--- a/code/run
+++ b/code/run
@@ -45,6 +45,7 @@ python -m exaspim_flatfield_correction.pipeline \
 --fitting-config "$9" \
 --worker-mode "${10}" \
 --background-smoothing-sigma "${13}" \
+--background-final-smoothing-sigma "${14:-0}" \
 --overwrite $EXTRA_FLAGS
 
 echo "Done!"

--- a/environment/postInstall
+++ b/environment/postInstall
@@ -9,7 +9,7 @@ conda activate correction
 
 git clone https://github.com/AllenNeuralDynamics/exaspim-flatfield-correction.git
 cd exaspim-flatfield-correction
-git checkout 8a80b815c4016033401505fef573c793261a21fd
+git checkout 049afd400104de91e38972d30bf0d438f06335f7
 pip install .
 
 pip install "aind-data-schema==2.6.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ packages = find:
 package_dir =
     =code
 install_requires =
+    pytest==9.0.3
     numpy>=2.1.0
     zarr==2.18.7
     numcodecs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+CODE_DIR = Path(__file__).resolve().parents[1] / "code"
+if str(CODE_DIR) not in sys.path:
+    sys.path.insert(0, str(CODE_DIR))

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import pytest
+import tifffile
 
 import dask.array as da
 import zarr
@@ -10,7 +13,10 @@ from exaspim_flatfield_correction.background import (
     estimate_bkg_from_mapped_slices,
     map_slice_indices_to_target,
 )
-from exaspim_flatfield_correction.pipeline import background_subtraction
+from exaspim_flatfield_correction.pipeline import (
+    background_subtraction,
+    save_method_outputs,
+)
 
 
 def _transform(z_scale: float, z_translation: float = 0.0) -> dict:
@@ -144,3 +150,25 @@ def test_background_subtraction_builds_background_from_target_planes() -> None:
         corrected.compute(),
         np.clip(full_res_data - expected_bkg, 0, None),
     )
+
+
+def test_save_method_outputs_writes_background_and_indices(tmp_path) -> None:
+    bkg = np.asarray([[1.5, 2.5], [3.5, 4.5]], dtype=np.float32)
+    indices = np.asarray([1, 3, 5], dtype=np.int64)
+
+    save_method_outputs(
+        "fitting",
+        "tile_000001",
+        str(tmp_path),
+        True,
+        bkg=bkg,
+        bkg_slice_indices=indices,
+    )
+
+    bkg_path = tmp_path / "tile_000001_bkg.tif"
+    indices_path = tmp_path / "tile_000001_bkg_slice_indices.json"
+
+    assert bkg_path.is_file()
+    assert indices_path.is_file()
+    np.testing.assert_array_equal(tifffile.imread(bkg_path), bkg)
+    assert json.loads(indices_path.read_text()) == [1, 3, 5]

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import dask.array as da
+import zarr
+
+from exaspim_flatfield_correction.background import (
+    estimate_bkg_from_mapped_slices,
+    map_slice_indices_to_target,
+)
+from exaspim_flatfield_correction.pipeline import background_subtraction
+
+
+def _transform(z_scale: float, z_translation: float = 0.0) -> dict:
+    return {
+        "scale": [1.0, 1.0, z_scale, 1.0, 1.0],
+        "translation": [0.0, 0.0, z_translation, 0.0, 0.0],
+    }
+
+
+def _write_multiscale_metadata(root: zarr.Group) -> None:
+    root.attrs["multiscales"] = [
+        {
+            "datasets": [
+                {
+                    "path": "0",
+                    "coordinateTransformations": [
+                        {"type": "scale", "scale": _transform(1)["scale"]},
+                        {
+                            "type": "translation",
+                            "translation": _transform(1)["translation"],
+                        },
+                    ],
+                },
+                {
+                    "path": "3",
+                    "coordinateTransformations": [
+                        {"type": "scale", "scale": _transform(2)["scale"]},
+                        {
+                            "type": "translation",
+                            "translation": _transform(2)["translation"],
+                        },
+                    ],
+                },
+            ]
+        }
+    ]
+
+
+def test_map_slice_indices_identity_with_metadata() -> None:
+    mapped = map_slice_indices_to_target(
+        np.asarray([0, 2]),
+        (4, 5, 6),
+        (4, 5, 6),
+        source_transformations=_transform(1),
+        target_transformations=_transform(1),
+    )
+
+    np.testing.assert_array_equal(mapped, np.asarray([0, 2]))
+
+
+def test_map_slice_indices_level3_to_level0_full_slab() -> None:
+    mapped = map_slice_indices_to_target(
+        np.asarray([2]),
+        (4, 5, 6),
+        (32, 40, 48),
+        source_transformations=_transform(8),
+        target_transformations=_transform(1),
+    )
+
+    np.testing.assert_array_equal(mapped, np.arange(16, 24))
+
+
+def test_map_slice_indices_honors_translation_metadata() -> None:
+    mapped = map_slice_indices_to_target(
+        np.asarray([2]),
+        (4, 5, 6),
+        (32, 40, 48),
+        source_transformations=_transform(8, z_translation=4),
+        target_transformations=_transform(1),
+    )
+
+    np.testing.assert_array_equal(mapped, np.arange(20, 28))
+
+
+def test_estimate_bkg_from_mapped_slices_uses_target_planes() -> None:
+    data = np.arange(4 * 2 * 3, dtype=np.float32).reshape(4, 2, 3)
+    target = da.from_array(data, chunks=(1, 1, 3))
+
+    bkg, target_indices = estimate_bkg_from_mapped_slices(
+        target,
+        np.asarray([1]),
+        (2, 2, 3),
+        source_transformations=_transform(2),
+        target_transformations=_transform(1),
+        max_spatial_chunk=1,
+    )
+
+    np.testing.assert_array_equal(target_indices, np.asarray([2, 3]))
+    np.testing.assert_array_equal(bkg, np.median(data[[2, 3]], axis=0))
+
+
+def test_background_subtraction_builds_background_from_target_planes() -> None:
+    store = zarr.storage.MemoryStore()
+    root = zarr.group(store=store)
+
+    full_res_data = np.asarray(
+        [
+            np.full((2, 2), 10, dtype=np.float32),
+            np.full((2, 2), 20, dtype=np.float32),
+            np.full((2, 2), 30, dtype=np.float32),
+            np.full((2, 2), 50, dtype=np.float32),
+        ]
+    )
+    low_res_data = np.asarray(
+        [
+            [[0, 100], [0, 100]],
+            [[1000, 1000], [1000, 1000]],
+        ],
+        dtype=np.float32,
+    )
+
+    root.create_dataset("0", data=full_res_data, chunks=(1, 2, 2))
+    root.create_dataset("3", data=low_res_data, chunks=(1, 2, 2))
+    _write_multiscale_metadata(root)
+
+    full_res = da.from_zarr(root["0"]).astype(np.float32)
+    corrected, bkg, bkg_slice_indices = background_subtraction(
+        "synthetic_tile.zarr",
+        full_res,
+        root,
+        is_binned_channel=False,
+        background_smoothing_sigma=0,
+        target_resolution="0",
+    )
+
+    expected_bkg = np.full((2, 2), 40, dtype=np.float32)
+    np.testing.assert_array_equal(bkg, expected_bkg)
+    np.testing.assert_array_equal(bkg_slice_indices, np.asarray([1]))
+    assert np.max(bkg_slice_indices) < root["3"].shape[0]
+    np.testing.assert_array_equal(
+        corrected.compute(),
+        np.clip(full_res_data - expected_bkg, 0, None),
+    )

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -8,13 +8,17 @@ import tifffile
 
 import dask.array as da
 import zarr
+from scipy.ndimage import gaussian_filter as gaussian_filter_np
 
+from exaspim_flatfield_correction import pipeline as pipeline_module
 from exaspim_flatfield_correction.background import (
     estimate_bkg_from_mapped_slices,
     map_slice_indices_to_target,
 )
 from exaspim_flatfield_correction.pipeline import (
     background_subtraction,
+    build_parser,
+    resolve_args,
     save_method_outputs,
 )
 
@@ -139,6 +143,7 @@ def test_background_subtraction_builds_background_from_target_planes() -> None:
         root,
         is_binned_channel=False,
         background_smoothing_sigma=0,
+        background_final_smoothing_sigma=0,
         target_resolution="0",
     )
 
@@ -147,6 +152,67 @@ def test_background_subtraction_builds_background_from_target_planes() -> None:
     np.testing.assert_array_equal(bkg_slice_indices, np.asarray([1]))
     assert np.max(bkg_slice_indices) < root["3"].shape[0]
     np.testing.assert_array_equal(
+        corrected.compute(),
+        np.clip(full_res_data - expected_bkg, 0, None),
+    )
+
+
+def test_background_subtraction_blurs_final_background_with_dask(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = zarr.storage.MemoryStore()
+    root = zarr.group(store=store)
+
+    raw_bkg = np.zeros((3, 3), dtype=np.float32)
+    raw_bkg[1, 1] = 90
+
+    full_res_data = np.zeros((4, 3, 3), dtype=np.float32)
+    full_res_data[2] = raw_bkg
+    full_res_data[3] = raw_bkg
+    low_res_data = np.asarray(
+        [
+            [[0, 100, 0], [100, 0, 100], [0, 100, 0]],
+            np.full((3, 3), 1000, dtype=np.float32),
+        ],
+        dtype=np.float32,
+    )
+
+    root.create_dataset("0", data=full_res_data, chunks=(1, 3, 3))
+    root.create_dataset("3", data=low_res_data, chunks=(1, 3, 3))
+    _write_multiscale_metadata(root)
+
+    calls = []
+    original_gaussian_filter = pipeline_module.gaussian_filter_dask
+
+    def spy_gaussian_filter(image, sigma, *args, **kwargs):
+        calls.append((image, sigma))
+        return original_gaussian_filter(image, sigma, *args, **kwargs)
+
+    monkeypatch.setattr(
+        pipeline_module,
+        "gaussian_filter_dask",
+        spy_gaussian_filter,
+    )
+
+    full_res = da.from_zarr(root["0"]).astype(np.float32)
+    corrected, bkg, _ = background_subtraction(
+        "synthetic_tile.zarr",
+        full_res,
+        root,
+        is_binned_channel=False,
+        background_smoothing_sigma=0,
+        background_final_smoothing_sigma=1,
+        target_resolution="0",
+    )
+
+    expected_bkg = gaussian_filter_np(raw_bkg, sigma=1).astype(np.float32)
+    assert bkg.dtype == np.float32
+    assert not np.array_equal(bkg, raw_bkg)
+    assert calls
+    assert calls[-1][1] == 1
+    assert calls[-1][0].shape == raw_bkg.shape
+    np.testing.assert_allclose(bkg, expected_bkg)
+    np.testing.assert_allclose(
         corrected.compute(),
         np.clip(full_res_data - expected_bkg, 0, None),
     )
@@ -172,3 +238,27 @@ def test_save_method_outputs_writes_background_and_indices(tmp_path) -> None:
     assert indices_path.is_file()
     np.testing.assert_array_equal(tifffile.imread(bkg_path), bkg)
     assert json.loads(indices_path.read_text()) == [1, 3, 5]
+
+
+def test_resolve_args_rejects_negative_final_background_smoothing() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "--tile-paths",
+            "tile.zarr",
+            "--output",
+            "out.zarr",
+            "--res",
+            "0",
+            "--method",
+            "fitting",
+            "--background-final-smoothing-sigma",
+            "-1",
+        ]
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="--background-final-smoothing-sigma must be non-negative",
+    ):
+        resolve_args(args, parser)

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -18,6 +18,7 @@ from exaspim_flatfield_correction.background import (
 from exaspim_flatfield_correction.pipeline import (
     background_subtraction,
     build_parser,
+    cleanup_background_cache,
     resolve_args,
     save_method_outputs,
 )
@@ -57,6 +58,13 @@ def _write_multiscale_metadata(root: zarr.Group) -> None:
             ]
         }
     ]
+
+
+def _graph_contains_text(arr: da.Array, text: str) -> bool:
+    graph = arr.__dask_graph__()
+    keys = list(graph.keys())
+    layer_names = list(getattr(graph, "layers", {}).keys())
+    return any(text in str(key) for key in keys + layer_names)
 
 
 def test_map_slice_indices_identity_with_metadata() -> None:
@@ -112,7 +120,7 @@ def test_estimate_bkg_from_mapped_slices_uses_target_planes() -> None:
     np.testing.assert_array_equal(bkg, np.median(data[[2, 3]], axis=0))
 
 
-def test_background_subtraction_builds_background_from_target_planes() -> None:
+def test_background_subtraction_uses_cached_background_zarr(tmp_path) -> None:
     store = zarr.storage.MemoryStore()
     root = zarr.group(store=store)
 
@@ -137,10 +145,12 @@ def test_background_subtraction_builds_background_from_target_planes() -> None:
     _write_multiscale_metadata(root)
 
     full_res = da.from_zarr(root["0"]).astype(np.float32)
-    corrected, bkg, bkg_slice_indices = background_subtraction(
+    corrected, bkg, bkg_slice_indices, cache_path = background_subtraction(
         "synthetic_tile.zarr",
         full_res,
         root,
+        str(tmp_path),
+        "synthetic_tile.zarr",
         is_binned_channel=False,
         background_smoothing_sigma=0,
         background_final_smoothing_sigma=0,
@@ -151,34 +161,43 @@ def test_background_subtraction_builds_background_from_target_planes() -> None:
     np.testing.assert_array_equal(bkg, expected_bkg)
     np.testing.assert_array_equal(bkg_slice_indices, np.asarray([1]))
     assert np.max(bkg_slice_indices) < root["3"].shape[0]
+    assert cache_path is not None
+    assert (cache_path / "final.zarr").is_dir()
+    assert _graph_contains_text(corrected, "bkg-cache-final")
     np.testing.assert_array_equal(
         corrected.compute(),
         np.clip(full_res_data - expected_bkg, 0, None),
     )
+    cleanup_background_cache(cache_path)
+    assert not cache_path.exists()
 
 
-def test_background_subtraction_blurs_final_background_with_dask(
+def test_background_subtraction_blurs_final_cached_background_with_dask(
+    tmp_path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = zarr.storage.MemoryStore()
     root = zarr.group(store=store)
 
-    raw_bkg = np.zeros((3, 3), dtype=np.float32)
-    raw_bkg[1, 1] = 90
+    raw_bkg = np.zeros((11, 11), dtype=np.float32)
+    raw_bkg[5, 5] = 90
 
-    full_res_data = np.zeros((4, 3, 3), dtype=np.float32)
+    full_res_data = np.zeros((4, 11, 11), dtype=np.float32)
     full_res_data[2] = raw_bkg
     full_res_data[3] = raw_bkg
+    foreground_slice = np.zeros((11, 11), dtype=np.float32)
+    foreground_slice[::2, 1::2] = 100
+    foreground_slice[1::2, ::2] = 100
     low_res_data = np.asarray(
         [
-            [[0, 100, 0], [100, 0, 100], [0, 100, 0]],
-            np.full((3, 3), 1000, dtype=np.float32),
+            foreground_slice,
+            np.full((11, 11), 1000, dtype=np.float32),
         ],
         dtype=np.float32,
     )
 
-    root.create_dataset("0", data=full_res_data, chunks=(1, 3, 3))
-    root.create_dataset("3", data=low_res_data, chunks=(1, 3, 3))
+    root.create_dataset("0", data=full_res_data, chunks=(1, 11, 11))
+    root.create_dataset("3", data=low_res_data, chunks=(1, 11, 11))
     _write_multiscale_metadata(root)
 
     calls = []
@@ -195,10 +214,12 @@ def test_background_subtraction_blurs_final_background_with_dask(
     )
 
     full_res = da.from_zarr(root["0"]).astype(np.float32)
-    corrected, bkg, _ = background_subtraction(
+    corrected, bkg, _, cache_path = background_subtraction(
         "synthetic_tile.zarr",
         full_res,
         root,
+        str(tmp_path),
+        "synthetic_tile.zarr",
         is_binned_channel=False,
         background_smoothing_sigma=0,
         background_final_smoothing_sigma=1,
@@ -211,11 +232,17 @@ def test_background_subtraction_blurs_final_background_with_dask(
     assert calls
     assert calls[-1][1] == 1
     assert calls[-1][0].shape == raw_bkg.shape
+    assert cache_path is not None
+    assert (cache_path / "raw.zarr").is_dir()
+    assert (cache_path / "final.zarr").is_dir()
+    assert _graph_contains_text(corrected, "bkg-cache-final")
     np.testing.assert_allclose(bkg, expected_bkg)
     np.testing.assert_allclose(
         corrected.compute(),
         np.clip(full_res_data - expected_bkg, 0, None),
     )
+    cleanup_background_cache(cache_path)
+    assert not cache_path.exists()
 
 
 def test_save_method_outputs_writes_background_and_indices(tmp_path) -> None:


### PR DESCRIPTION
## Summary

This PR improves background subtraction by using low-resolution data only to identify likely background-dominant Z slices, then mapping those slices back to the target-resolution volume before estimating and subtracting the final background image.

The motivation is that estimating the background image directly at a lower resolution can be inaccurate because downsampling changes the image statistics. This is especially noticeable in very low-SNR exaSPIM data, where the tissue-level intensity can be just 1 count above the background on average. Depending on the downsampling method used, such as mean vs 2nd-brightest voxel, the previous approach could overcorrect or undercorrect the target-resolution image.

By mapping the selected background slices back to the target resolution and computing the final 2D background from those target-resolution planes, the subtraction now uses image statistics aligned with the data being corrected.

## Approach

This PR separates slice selection from final background estimation:

1. Use the lower-resolution selector volume to identify background-dominant Z slices.
2. Read OME-Zarr scale and translation metadata for both the selector resolution and the target resolution.
3. Map the selected source Z slices into the target-resolution coordinate system.
4. Compute the final 2D background image from the mapped target-resolution planes.
5. Subtract that target-resolution background from the target-resolution image.

This preserves the efficiency and robustness of low-resolution slice selection while ensuring that the final background image is estimated from data with matching target-resolution statistics.