### PR TITLE
BREAKING CHANGE: Remove CLI args and use Pydantic model for pipeline config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,36 +17,54 @@ ExASPIM Flatfield Correction provides background subtraction and flatfield corre
 The main entry point is exposed as `exaspim-flatfield-run`. You can also invoke the module directly via `python -m exaspim_flatfield_correction.pipeline`.
 
 ```sh
-exaspim-flatfield-run \
-  --zarr s3://bucket/tile_00001.ome.zarr \
-  --output s3://bucket/corrected/tile_00001.ome.zarr \
-  --method fitting \
-  --mask-dir /path/to/masks \
-  --num-workers 8 \
-  --n-levels 4
+exaspim-flatfield-run --config /data/config.json
 ```
 
-Essential arguments:
-- `--zarr`: input tile in OME-Zarr format (local path or S3 URI). When omitted, the pipeline searches for `../data/tile_*.json` metadata.
-- `--output`: destination OME-Zarr path for the corrected volume.
-- `--method`: `reference`, `basicpy`, or `fitting`. The fitting workflow requires `--mask-dir`; the reference workflow expects `--flatfield-path`.
-- `--res`: resolution key to process (default `0`).
+All pipeline options are supplied through the JSON config. Unknown keys are rejected, so use the canonical field names shown below.
 
-Frequently used options:
-- `--num-workers`: number of Dask workers to launch (one thread per worker).
-- `--results-dir`: directory for logs, diagnostics, and exported artifacts (defaults to `./results`).
-- `--save-outputs`: persist intermediate TIFFs and plots inside `results/`.
-- `--n-levels`: number of multiscale pyramid levels to generate for outputs.
-- `--use-reference-bkg`: reuse precomputed background instead of estimating from the data.
-- `--background-smoothing-sigma`: Gaussian smoothing sigma applied before background estimation; set to `0` to disable smoothing.
-- `--fitting-config`: JSON file with overrides for mask refinement, percentile weights, spline smoothing, and global normalization.
-- `--median-summary-path`: per-channel normalization overrides produced by upstream statistics.
-- `--is-binned`: flag tiles that correspond to a binned channel so the pipeline adjusts resolution handling.
+```json
+{
+  "method": "fitting",
+  "tile_paths": [
+    "s3://aind-open-data/exaSPIM_826506_2026-05-19_14-00-17_processed_2026-06-04_14-18-27/denoised/SPIM.ome.zarr/tile_000001_ch_488.zarr",
+    "s3://aind-open-data/exaSPIM_826506_2026-05-19_14-00-17_processed_2026-06-04_14-18-27/denoised/SPIM.ome.zarr/tile_000001_ch_561.zarr"
+  ],
+  "output": "s3://aind-open-data/exaSPIM_826506_2026-05-19_14-00-17_processed_2026-06-04_14-18-27/flatfield_correction/SPIM.ome.zarr",
+  "binned_channel": "561",
+  "res": 0,
+  "skip_flat_field": false,
+  "skip_bkg_sub": false,
+  "mask_dir": "/data/masks",
+  "fitting_config": "/data/fitting_config.json",
+  "worker_mode": "processes",
+  "background_smoothing_sigma": 3.0,
+  "num_workers": 16,
+  "n_levels": 7,
+  "results_dir": "/results",
+  "save_outputs": true,
+  "overwrite": true
+}
+```
+
+Frequently used config fields:
+- `tile_paths`: one or more input tile OME-Zarr paths.
+- `output`: destination OME-Zarr path for corrected volumes.
+- `method`: `reference`, `basicpy`, or `fitting`. The fitting workflow requires `mask_dir`; the reference workflow expects `flatfield_path`.
+- `res`: resolution key to process; numbers are normalized to strings.
+- `num_workers`: number of Dask workers to launch.
+- `results_dir`: directory for logs, diagnostics, and exported artifacts.
+- `save_outputs`: persist intermediate TIFFs and plots inside `results_dir`.
+- `n_levels`: number of multiscale pyramid levels to generate for outputs.
+- `use_reference_bkg`: reuse precomputed background instead of estimating from the data.
+- `background_smoothing_sigma`: Gaussian smoothing sigma applied before background estimation; set to `0` to disable smoothing.
+- `fitting_config`: JSON file with overrides for mask refinement, percentile weights, spline smoothing, and global normalization.
+- `median_summary_path`: per-channel normalization overrides produced by upstream statistics.
+- `is_binned`: flag all configured tiles as binned; when `binned_channel` is omitted, it is inferred from the first tile name when possible.
 
 The pipeline honours the `CO_MEMORY` environment variable (bytes) when sizing the Dask cluster and expects AWS credentials in the environment when reading or writing S3 paths.
 
 ## Outputs
-Each tile run writes corrected data to the requested `--output` location and emits auxiliary OME-Zarr artifacts alongside it:
+Each tile run writes corrected data to the requested `output` location and emits auxiliary OME-Zarr artifacts alongside it:
 - `mask/<tile>/0/…`: upsampled foreground mask used for fitting.
 - `probability/<tile>/0/…`: percentile-based probability weights when GMM refinement is enabled in the fitting configuration.
 - `results/`: pipeline metadata, diagnostics, and optional cached intermediates.

--- a/code/exaspim_flatfield_correction/__init__.py
+++ b/code/exaspim_flatfield_correction/__init__.py
@@ -1,3 +1,3 @@
 """Top-level package for exaspim flatfield correction."""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/code/exaspim_flatfield_correction/config.py
+++ b/code/exaspim_flatfield_correction/config.py
@@ -1,15 +1,167 @@
-"""Configuration helpers for fitting-based flatfield correction."""
+"""Configuration helpers for flatfield correction."""
 
 from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+
+from exaspim_flatfield_correction.utils.utils import (
+    extract_channel_from_tile_name,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class PipelineConfig(BaseModel):
+    """Top-level configuration for the flatfield correction pipeline."""
+
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    tile_paths: list[str] = Field(
+        min_length=1,
+        description="One or more input OME-Zarr tile paths.",
+    )
+    output: str = Field(
+        min_length=1,
+        description="Output OME-Zarr path for corrected data.",
+    )
+    save_outputs: bool = Field(
+        default=False,
+        description="Save intermediate output files.",
+    )
+    results_dir: str = Field(
+        default_factory=lambda: os.path.join(os.getcwd(), "results"),
+        description="Directory for results, diagnostics, and metadata.",
+    )
+    res: str = Field(
+        default="0",
+        min_length=1,
+        description="Resolution level to process.",
+    )
+    method: Literal["basicpy", "reference", "fitting"] = Field(
+        default="fitting",
+        description="Flatfield correction method.",
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Overwrite existing outputs.",
+    )
+    skip_flat_field: bool = Field(
+        default=False,
+        description="Skip flatfield correction.",
+    )
+    skip_bkg_sub: bool = Field(
+        default=False,
+        description="Skip background subtraction.",
+    )
+    flatfield_path: str | None = Field(
+        default=None,
+        description="Reference flatfield image path.",
+    )
+    mask_dir: str | None = Field(
+        default=None,
+        description="Directory containing fitting masks.",
+    )
+    fitting_config: str | None = Field(
+        default=None,
+        description="Path to fitting configuration overrides.",
+    )
+    num_workers: int = Field(
+        default=1,
+        ge=1,
+        description="Number of Dask workers to launch.",
+    )
+    worker_mode: Literal["processes", "threads"] = Field(
+        default="processes",
+        description="Dask worker execution mode.",
+    )
+    log_level: int | str = Field(
+        default=logging.INFO,
+        description="Python logging level for the pipeline logger.",
+    )
+    n_levels: int = Field(
+        default=1,
+        ge=1,
+        description="Number of OME-Zarr pyramid levels to write.",
+    )
+    use_reference_bkg: bool = Field(
+        default=False,
+        description="Use a reference background image instead of estimating.",
+    )
+    background_smoothing_sigma: float = Field(
+        default=1.0,
+        ge=0,
+        description="Gaussian sigma applied before background estimation.",
+    )
+    background_final_smoothing_sigma: float = Field(
+        default=0.0,
+        ge=0,
+        description="Gaussian sigma applied to the final background image.",
+    )
+    binned_channel: str | None = Field(
+        default=None,
+        description="Substring identifying binned channel tiles.",
+    )
+    is_binned: bool = Field(
+        default=False,
+        description="Treat all configured tiles as binned channel data.",
+    )
+    median_summary_path: str | None = Field(
+        default=None,
+        description="Path to per-channel median intensity summary JSON.",
+    )
+
+    @field_validator("res", mode="before")
+    @classmethod
+    def _normalize_res(cls, value: Any) -> str:
+        if value in (None, ""):
+            raise ValueError("res cannot be empty")
+        return str(value)
+
+    @model_validator(mode="after")
+    def _validate_method_requirements(self) -> "PipelineConfig":
+        if self.method == "fitting" and self.mask_dir is None:
+            raise ValueError("mask_dir is required when method='fitting'")
+        if (
+            self.method == "fitting"
+            and not self.skip_flat_field
+            and self.skip_bkg_sub
+        ):
+            raise ValueError(
+                "active fitting correction requires background subtraction"
+            )
+        if (
+            self.method == "reference"
+            and not self.skip_flat_field
+            and self.flatfield_path is None
+        ):
+            raise ValueError(
+                "flatfield_path is required when active method='reference'"
+            )
+
+        if self.is_binned and self.binned_channel is None:
+            tile_name = Path(self.tile_paths[0]).name
+            inferred_channel = extract_channel_from_tile_name(tile_name)
+            if inferred_channel is not None:
+                self.binned_channel = inferred_channel
+            else:
+                _LOGGER.warning(
+                    "Unable to infer channel number from tile %s despite "
+                    "is_binned=true",
+                    tile_name,
+                )
+        return self
 
 
 class FittingConfig(BaseModel):
@@ -248,6 +400,17 @@ def load_fitting_config(path: str | Path | None = None) -> FittingConfig:
     if path is None:
         return FittingConfig()
     return FittingConfig.from_file(path)
+
+
+def load_pipeline_config(path: str | Path) -> PipelineConfig:
+    """Load and validate the top-level pipeline configuration."""
+
+    config_path = Path(path)
+    if not config_path.is_file():
+        raise ValueError(f"Config file not found: {config_path}")
+    raw = config_path.read_text()
+    data: Any = json.loads(raw)
+    return PipelineConfig.model_validate(data)
 
 
 def read_median_intensity_summary(

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -29,8 +29,10 @@ from exaspim_flatfield_correction.background import (
 from exaspim_flatfield_correction.basic import fit_basic, transform_basic
 from exaspim_flatfield_correction.config import (
     FittingConfig,
+    PipelineConfig,
     apply_median_summary_override,
     load_fitting_config,
+    load_pipeline_config,
     read_median_intensity_summary,
 )
 from exaspim_flatfield_correction.fitting import (
@@ -49,7 +51,6 @@ from exaspim_flatfield_correction.utils.metadata_utils import (
 from exaspim_flatfield_correction.utils.utils import (
     array_chunks,
     chunks_2d,
-    extract_channel_from_tile_name,
     get_bkg_path,
     get_parent_s3_path,
     load_mask_from_dir,
@@ -57,7 +58,7 @@ from exaspim_flatfield_correction.utils.utils import (
     resize,
     save_correction_curve_plot,
     upload_artifacts,
-    weighted_percentile
+    weighted_percentile,
 )
 from exaspim_flatfield_correction.utils.zarr_utils import (
     initialize_zarr_group,
@@ -80,145 +81,6 @@ class MaskArtifacts:
 
     mask_low_res: da.Array
     probability_volume: da.Array | None = None
-
-
-def resolve_args(
-    args: argparse.Namespace, parser: argparse.ArgumentParser
-) -> argparse.Namespace:
-    """Merge CLI args with optional JSON config (config takes precedence).
-
-    Parameters
-    ----------
-    args : argparse.Namespace
-        Parsed command-line arguments (pre-merge with config).
-    parser : argparse.ArgumentParser
-        Argument parser used to define available options; used to reconcile
-        config keys against all CLI arguments.
-
-    Returns
-    -------
-    argparse.Namespace
-        The input namespace updated with config overrides and inferred values.
-
-    Raises
-    ------
-    ValueError
-        If required values cannot be resolved.
-    """
-    config: dict[str, Any] = {}
-    if args.config:
-        config_path = Path(args.config)
-        if not config_path.is_file():
-            raise ValueError(f"Config file not found: {args.config}")
-        with open(config_path, "r") as f:
-            config = json.load(f)
-
-    allowed_config_keys = {
-        action.dest for action in parser._actions if action.dest != "help"
-    } | {"binned_channel"}
-    unknown_keys = set(config) - allowed_config_keys
-    if unknown_keys:
-        _LOGGER.warning(
-            "Ignoring unrecognized config keys: %s",
-            ", ".join(sorted(unknown_keys)),
-        )
-
-    # Merge config over CLI for every parser-defined argument
-    merged_cli: dict[str, Any] = {}
-    for action in parser._actions:
-        dest = action.dest
-        if dest == "help":
-            continue
-        if dest in config and config[dest] not in (None, ""):
-            val = config[dest]
-            if action.type and val is not None:
-                try:
-                    if isinstance(val, (list, tuple)):
-                        val = [action.type(v) for v in val]
-                    else:
-                        val = action.type(val)
-                except Exception as exc:  # noqa: BLE001
-                    raise ValueError(
-                        f"Invalid value for '{dest}' in config: {val}"
-                    ) from exc
-            merged_cli[dest] = val
-        else:
-            merged_cli[dest] = getattr(args, dest, action.default)
-
-    # Resolve primary inputs (config → CLI)
-    tile_paths = merged_cli.get("tile_paths")
-    if isinstance(tile_paths, str):
-        tile_paths = [tile_paths]
-    elif tile_paths is not None:
-        tile_paths = [str(p) for p in tile_paths]
-    merged_cli["tile_paths"] = tile_paths
-    if not tile_paths:
-        raise ValueError(
-            "No tile paths provided. Supply --tile-paths or set 'tile_paths' "
-            "in the config file."
-        )
-
-    if not merged_cli.get("output"):
-        raise ValueError(
-            "No output path provided. Supply --output or set 'output' in the "
-            "config file."
-        )
-
-    if merged_cli.get("method") not in {"basicpy", "reference", "fitting"}:
-        raise ValueError(
-            "Invalid method specified. Choose from 'basicpy', 'reference', or 'fitting'."
-        )
-
-    res_value = merged_cli.get("res")
-    res = str(res_value) if res_value not in (None, "") else None
-    merged_cli["res"] = res
-    if res is None:
-        raise ValueError(
-            "--res cannot be None."
-        )
-
-    merged_cli["skip_bkg_sub"] = merged_cli.get("skip_bkg_sub", False)
-    merged_cli["skip_flat_field"] = merged_cli.get("skip_flat_field", False)
-    merged_cli["is_binned"] = merged_cli.get("is_binned", False)
-    background_smoothing_sigma = merged_cli.get("background_smoothing_sigma")
-    if background_smoothing_sigma is None:
-        background_smoothing_sigma = 1.0
-    if background_smoothing_sigma < 0:
-        raise ValueError(
-            "--background-smoothing-sigma must be non-negative."
-        )
-    merged_cli["background_smoothing_sigma"] = background_smoothing_sigma
-
-    background_final_smoothing_sigma = merged_cli.get(
-        "background_final_smoothing_sigma"
-    )
-    if background_final_smoothing_sigma is None:
-        background_final_smoothing_sigma = 0.0
-    if background_final_smoothing_sigma < 0:
-        raise ValueError(
-            "--background-final-smoothing-sigma must be non-negative."
-        )
-    merged_cli["background_final_smoothing_sigma"] = (
-        background_final_smoothing_sigma
-    )
-
-    binned_channel = merged_cli.get("binned_channel")
-    if binned_channel is None and merged_cli["is_binned"]:
-        tile_name = Path(tile_paths[0]).name
-        inferred_channel = extract_channel_from_tile_name(tile_name)
-        if inferred_channel is not None:
-            binned_channel = inferred_channel
-        else:
-            _LOGGER.warning(
-                "Unable to infer channel number from tile %s despite --is-binned/config flag",
-                tile_name,
-            )
-    merged_cli["binned_channel"] = binned_channel
-
-    # Propagate merged values back into args for downstream consumers
-    for key, value in merged_cli.items():
-        setattr(args, key, value)
-    return args
 
 
 def background_subtraction(
@@ -1001,7 +863,7 @@ def save_method_outputs(
 def process_tile(
     tile_path: str,
     *,
-    args: argparse.Namespace,
+    args: PipelineConfig,
     method: str,
     res: str,
     binned_channel: str | None,
@@ -1207,118 +1069,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--config",
         type=str,
-        default=None,
+        required=True,
         help="Path to a JSON config file containing pipeline inputs.",
-    )
-    parser.add_argument(
-        "--tile-paths",
-        nargs="+",
-        dest="tile_paths",
-        type=str,
-        required=False,
-        default=None,
-        help="One or more input zarr paths for the tile data",
-    )
-    parser.add_argument(
-        "--output",
-        type=str,
-        required=False,
-        default=None,
-        help="Output zarr path for the corrected data",
-    )
-    parser.add_argument(
-        "--save-outputs",
-        default=False,
-        action="store_true",
-        help="Save intermediate output files.",
-    )
-    parser.add_argument(
-        "--results-dir",
-        type=str,
-        default=os.path.join(os.getcwd(), "results"),
-        help="Directory to save results and metadata.",
-    )
-    parser.add_argument(
-        "--res",
-        type=str,
-        default="0",
-        help="Resolution level to process (default: 0)",
-    )
-    parser.add_argument(
-        "--method",
-        type=str,
-        choices=["basicpy", "reference", "fitting"],
-        default="fitting",
-    )
-    parser.add_argument("--overwrite", default=False, action="store_true")
-    parser.add_argument(
-        "--skip-flat-field", action="store_true", default=False
-    )
-    parser.add_argument("--skip-bkg-sub", action="store_true", default=False)
-    parser.add_argument("--flatfield-path", type=str, default=None)
-    parser.add_argument("--mask-dir", type=str, default=None)
-    parser.add_argument(
-        "--fitting-config",
-        type=str,
-        default=None,
-        help="Path to a JSON file with fitting configuration overrides.",
-    )
-    parser.add_argument("--num-workers", type=int, default=1)
-    parser.add_argument(
-        "--worker-mode",
-        type=str,
-        choices=["processes", "threads"],
-        default="processes",
-        help="Execution mode for Dask workers (default: processes).",
-    )
-    parser.add_argument("--log-level", type=str, default=logging.INFO)
-    parser.add_argument(
-        "--n-levels",
-        type=int,
-        default=1,
-        help="Number of zarr pyramid levels (default: 1)",
-    )
-    parser.add_argument(
-        "--use-reference-bkg",
-        action="store_true",
-        default=False,
-        help="Use reference background image from S3 instead of estimating background.",
-    )
-    parser.add_argument(
-        "--background-smoothing-sigma",
-        type=float,
-        default=1.0,
-        help=(
-            "Gaussian smoothing sigma applied before background estimation. "
-            "Set to 0 to disable smoothing."
-        ),
-    )
-    parser.add_argument(
-        "--background-final-smoothing-sigma",
-        type=float,
-        default=0.0,
-        help=(
-            "Gaussian smoothing sigma applied to the final 2D background "
-            "image before subtraction and saving. Set to 0 to disable final "
-            "background smoothing."
-        ),
-    )
-    parser.add_argument(
-        "--binned-channel",
-        type=str,
-        default=None,
-        help="Substring identifying binned channel tiles (e.g., '488').",
-    )
-    parser.add_argument("--is-binned", action="store_true", default=False)
-    parser.add_argument(
-        "--median-summary-path",
-        type=str,
-        default=None,
-        help=(
-            "Path to a JSON file containing per-channel mean_of_medians values "
-            "for global normalization. Overrides the value stored in the fitting "
-            "configuration when provided."
-        ),
     )
     return parser
 
@@ -1346,19 +1098,11 @@ def create_zarr_artifact_path(out_zarr_path: str, dirname: str) -> str:
 def main() -> None:
     """Execute the flatfield correction pipeline for the requested tiles."""
     parser = build_parser()
-    args = parser.parse_args()
+    cli_args = parser.parse_args()
+    args = load_pipeline_config(cli_args.config)
     _LOGGER.setLevel(args.log_level)
 
-    _LOGGER.info(f"args: {args}")
-
-    args = resolve_args(args, parser)
-    _LOGGER.info(f"Resolved parameters: {args}")
-
-    if args.method == "fitting" and args.mask_dir is None:
-        raise ValueError(
-            "Mask directory (--mask-dir) must be specified when using the "
-            "'fitting' method."
-        )
+    _LOGGER.info("Pipeline parameters: %s", args.model_dump(mode="json"))
 
     results_dir = args.results_dir
     if not os.path.exists(results_dir):

--- a/code/exaspim_flatfield_correction/utils/metadata_utils.py
+++ b/code/exaspim_flatfield_correction/utils/metadata_utils.py
@@ -37,9 +37,14 @@ def _serialize_parameter_value(value: Any) -> Any:
 
 def _get_code_parameters(args: Any, output_path: str, res: str) -> dict[str, Any]:
     """Build metadata for the resolved pipeline invocation."""
+    model_dump = getattr(args, "model_dump", None)
+    if callable(model_dump):
+        raw_parameters = model_dump(mode="json")
+    else:
+        raw_parameters = vars(args)
     parameters = {
         key: _serialize_parameter_value(value)
-        for key, value in vars(args).items()
+        for key, value in raw_parameters.items()
     }
     if parameters.get("res") in (None, ""):
         parameters["res"] = res

--- a/environment/postInstall
+++ b/environment/postInstall
@@ -9,7 +9,7 @@ conda activate correction
 
 git clone https://github.com/AllenNeuralDynamics/exaspim-flatfield-correction.git
 cd exaspim-flatfield-correction
-git checkout 8ffcb7642bf7b3df5efcb6d4b5b8e2c6d87d5be1
+git checkout 8427ec6ec9c2976e6f4726ae929ec05643a608d2
 pip install .
 
 pip install "aind-data-schema==2.6.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ include_package_data = True
 
 [options.entry_points]
 console_scripts =
-    exaspim-flatfield-run = exaspim_flatfield_correction.pipeline.run_pipeline:main
+    exaspim-flatfield-run = exaspim_flatfield_correction.pipeline:main
 
 [options.packages.find]
 where=code

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -17,9 +17,7 @@ from exaspim_flatfield_correction.background import (
 )
 from exaspim_flatfield_correction.pipeline import (
     background_subtraction,
-    build_parser,
     cleanup_background_cache,
-    resolve_args,
     save_method_outputs,
 )
 
@@ -265,27 +263,3 @@ def test_save_method_outputs_writes_background_and_indices(tmp_path) -> None:
     assert indices_path.is_file()
     np.testing.assert_array_equal(tifffile.imread(bkg_path), bkg)
     assert json.loads(indices_path.read_text()) == [1, 3, 5]
-
-
-def test_resolve_args_rejects_negative_final_background_smoothing() -> None:
-    parser = build_parser()
-    args = parser.parse_args(
-        [
-            "--tile-paths",
-            "tile.zarr",
-            "--output",
-            "out.zarr",
-            "--res",
-            "0",
-            "--method",
-            "fitting",
-            "--background-final-smoothing-sigma",
-            "-1",
-        ]
-    )
-
-    with pytest.raises(
-        ValueError,
-        match="--background-final-smoothing-sigma must be non-negative",
-    ):
-        resolve_args(args, parser)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from exaspim_flatfield_correction.config import (
+    PipelineConfig,
+    load_pipeline_config,
+)
+
+
+def _sample_pipeline_config() -> dict[str, object]:
+    return {
+        "method": "fitting",
+        "tile_paths": [
+            (
+                "s3://aind-open-data/"
+                "exaSPIM_826506_2026-05-19_14-00-17_processed_"
+                "2026-06-04_14-18-27/denoised/SPIM.ome.zarr/"
+                "tile_000001_ch_488.zarr"
+            ),
+            (
+                "s3://aind-open-data/"
+                "exaSPIM_826506_2026-05-19_14-00-17_processed_"
+                "2026-06-04_14-18-27/denoised/SPIM.ome.zarr/"
+                "tile_000001_ch_561.zarr"
+            ),
+        ],
+        "output": (
+            "s3://aind-open-data/"
+            "exaSPIM_826506_2026-05-19_14-00-17_processed_"
+            "2026-06-04_14-18-27/flatfield_correction/SPIM.ome.zarr"
+        ),
+        "binned_channel": "561",
+        "res": 0,
+        "skip_flat_field": False,
+        "skip_bkg_sub": False,
+        "mask_dir": "/data/masks",
+        "fitting_config": "/data/fitting_config.json",
+        "worker_mode": "processes",
+        "background_smoothing_sigma": 3.0,
+        "num_workers": 16,
+        "n_levels": 7,
+        "results_dir": "/results",
+        "save_outputs": True,
+        "overwrite": True,
+    }
+
+
+def test_pipeline_config_validates_sample_and_normalizes_res() -> None:
+    config = PipelineConfig.model_validate(_sample_pipeline_config())
+
+    assert config.res == "0"
+    assert config.method == "fitting"
+    assert config.tile_paths[0].endswith("tile_000001_ch_488.zarr")
+    assert config.output.endswith("flatfield_correction/SPIM.ome.zarr")
+
+
+def test_load_pipeline_config_from_file(tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(_sample_pipeline_config()))
+
+    config = load_pipeline_config(config_path)
+
+    assert config.res == "0"
+    assert config.num_workers == 16
+
+
+@pytest.mark.parametrize("extra_key", ["output_zarr", "resolution"])
+def test_pipeline_config_rejects_legacy_schema_keys(extra_key: str) -> None:
+    payload = _sample_pipeline_config()
+    payload[extra_key] = "legacy-value"
+
+    with pytest.raises(ValueError, match=extra_key):
+        PipelineConfig.model_validate(payload)
+
+
+def test_pipeline_config_rejects_negative_final_background_smoothing() -> None:
+    payload = _sample_pipeline_config()
+    payload["background_final_smoothing_sigma"] = -1
+
+    with pytest.raises(
+        ValueError,
+        match="background_final_smoothing_sigma",
+    ):
+        PipelineConfig.model_validate(payload)
+
+
+def test_pipeline_config_requires_mask_dir_for_fitting() -> None:
+    payload = _sample_pipeline_config()
+    payload.pop("mask_dir")
+
+    with pytest.raises(ValueError, match="mask_dir"):
+        PipelineConfig.model_validate(payload)
+
+
+def test_pipeline_config_rejects_active_fitting_without_background() -> None:
+    payload = _sample_pipeline_config()
+    payload["skip_bkg_sub"] = True
+
+    with pytest.raises(ValueError, match="background subtraction"):
+        PipelineConfig.model_validate(payload)
+
+
+def test_pipeline_config_requires_flatfield_for_active_reference() -> None:
+    payload = _sample_pipeline_config()
+    payload["method"] = "reference"
+    payload.pop("mask_dir")
+
+    with pytest.raises(ValueError, match="flatfield_path"):
+        PipelineConfig.model_validate(payload)
+
+
+def test_pipeline_config_infers_binned_channel_when_marked_binned() -> None:
+    payload = _sample_pipeline_config()
+    payload.pop("binned_channel")
+    payload["is_binned"] = True
+
+    config = PipelineConfig.model_validate(payload)
+
+    assert config.binned_channel == "488"


### PR DESCRIPTION
This pull request introduces a major refactor to the configuration system for the flatfield correction pipeline, shifting from a mix of command-line arguments and optional config files to a single, strictly validated JSON configuration file. The changes simplify pipeline invocation, enforce configuration correctness, and improve maintainability by centralizing all options in a Pydantic-based model. The CLI now only accepts a `--config` argument, and all other parameters must be specified in the JSON config. The documentation and code have been updated to reflect this new approach.

**Configuration system refactor:**

* Added a new `PipelineConfig` Pydantic model in `config.py` to define, validate, and document all pipeline options, replacing the previous ad-hoc argument parsing and merging logic.
* Introduced the `load_pipeline_config` function to load and validate the pipeline configuration from a JSON file.
* Removed the complex `resolve_args` CLI/config merging function and all individual CLI arguments except for `--config` in `pipeline.py`. [[1]](diffhunk://#diff-1a804196c3f8cbd9cba93008d23de6bfd207fa65df3e82abd6c0c2d464737aa9L85-L223) [[2]](diffhunk://#diff-1a804196c3f8cbd9cba93008d23de6bfd207fa65df3e82abd6c0c2d464737aa9L1210-L1322)
* Updated the pipeline entry point to require a config file, and to log and pass around a validated `PipelineConfig` object instead of a mutable `argparse.Namespace`. [[1]](diffhunk://#diff-1a804196c3f8cbd9cba93008d23de6bfd207fa65df3e82abd6c0c2d464737aa9L1349-R1105) [[2]](diffhunk://#diff-1a804196c3f8cbd9cba93008d23de6bfd207fa65df3e82abd6c0c2d464737aa9L1004-R866)
* Updated metadata serialization utilities to support both `PipelineConfig` and legacy `Namespace` objects.

**Documentation and versioning:**

* Updated the `README.md` to document the new JSON config approach, removing all references to individual CLI arguments and providing an example config.
* Bumped the package version to `0.1.3` to reflect the breaking changes. (F8f9e41fL1)

**Miscellaneous:**

* Updated the `postInstall` script to check out the latest commit for the package.