### PR TITLE
Feat: Zarr v3 output support, TensorStore I/O backend, and sharded artifacts

### DIFF
--- a/.codeocean/resources.json
+++ b/.codeocean/resources.json
@@ -1,7 +1,4 @@
 {
 	"version": 1,
-	"resource_class": "dedicated",
-	"machine_config": {
-		"instance_type": "r6a.8xlarge"
-	}
+	"resource_class": "large"
 }

--- a/.codeocean/secrets.json
+++ b/.codeocean/secrets.json
@@ -1,0 +1,13 @@
+{
+	"version": 1,
+	"secrets": [
+		{
+			"type": "aws",
+			"id": "QqBXSmCqs32jDmkO",
+			"description": "AWS Assumable Role - aind-codeocean-power-user",
+			"access_key_id": "AWS_ACCESS_KEY_ID",
+			"secret_access_key": "AWS_SECRET_ACCESS_KEY",
+			"region": "AWS_DEFAULT_REGION"
+		}
+	]
+}

--- a/code/exaspim_flatfield_correction/__init__.py
+++ b/code/exaspim_flatfield_correction/__init__.py
@@ -1,3 +1,3 @@
 """Top-level package for exaspim flatfield correction."""
 
-__version__ = "0.1.3"
+__version__ = "0.2.0"

--- a/code/exaspim_flatfield_correction/config.py
+++ b/code/exaspim_flatfield_correction/config.py
@@ -177,6 +177,26 @@ class PipelineConfig(BaseModel):
             "the input tile's format (v2 or v3); '2' or '3' force a format."
         ),
     )
+    mask_shard_size: tuple[int, int, int] | None = Field(
+        default=(1024, 1024, 1024),
+        description=(
+            "ZYX shard shape for the sparse mask and probability volumes, which are "
+            "always written as Zarr v3 so many tiny compressed chunks pack into one "
+            "shard object (fewer S3 objects). The shard is snapped up/down to a whole "
+            "multiple of the array's inner chunk. Set to null to disable sharding."
+        ),
+    )
+    corrected_shard_size: tuple[int, int, int] | None = Field(
+        default=(512, 512, 512),
+        description=(
+            "ZYX shard shape for the dense corrected output, applied only when the "
+            "output is Zarr v3 (output_zarr_format=3); ignored for v2. Sharding packs "
+            "many inner chunks into one shard object (fewer S3 objects). Note: each "
+            "write task materializes a full shard (~shard_volume x 2 bytes of RAM), so "
+            "keep this modest relative to worker memory. The shard is snapped to a whole "
+            "multiple of the tile's inner chunk. Set to null to disable sharding."
+        ),
+    )
     corrected_rank: int = Field(
         default=-2,
         description=(

--- a/code/exaspim_flatfield_correction/config.py
+++ b/code/exaspim_flatfield_correction/config.py
@@ -47,22 +47,22 @@ class IOConcurrencyConfig(BaseModel):
         description="Zarr internal thread-pool worker limit (zarr backend).",
     )
     tensorstore_data_copy_concurrency: int | None = Field(
-        default=4,
+        default=8,
         ge=1,
         description="TensorStore data-copy concurrency limit (tensorstore backend).",
     )
     tensorstore_file_io_concurrency: int | None = Field(
-        default=4,
+        default=8,
         ge=1,
         description="TensorStore file I/O concurrency limit (tensorstore backend).",
     )
     tensorstore_s3_request_concurrency: int | None = Field(
-        default=4,
+        default=8,
         ge=1,
         description="TensorStore S3 request concurrency limit (tensorstore backend).",
     )
     tensorstore_http_request_concurrency: int | None = Field(
-        default=4,
+        default=8,
         ge=1,
         description="TensorStore HTTP request concurrency limit (tensorstore backend).",
     )

--- a/code/exaspim_flatfield_correction/config.py
+++ b/code/exaspim_flatfield_correction/config.py
@@ -186,6 +186,17 @@ class PipelineConfig(BaseModel):
             "multiple of the array's inner chunk. Set to null to disable sharding."
         ),
     )
+    probability_shard_size: tuple[int, int, int] | None = Field(
+        default=(512, 512, 512),
+        description=(
+            "ZYX shard shape for the always-v3 probability volume. Kept smaller than "
+            "mask_shard_size because the probability volume is float32 and, for binned "
+            "channels, full-resolution: each write task materializes a full shard "
+            "(~shard_volume x 4 bytes of RAM), so 1024^3 (~4 GiB) overflows the ~8 GB "
+            "per-worker budget in processes mode. The shard is snapped to a whole "
+            "multiple of the inner chunk. Set to null to disable sharding."
+        ),
+    )
     corrected_shard_size: tuple[int, int, int] | None = Field(
         default=(512, 512, 512),
         description=(

--- a/code/exaspim_flatfield_correction/config.py
+++ b/code/exaspim_flatfield_correction/config.py
@@ -16,11 +16,60 @@ from pydantic import (
     model_validator,
 )
 
+from zarr_io.config import IOConcurrencyConfig as _ZarrIOConcurrencyConfig
+
 from exaspim_flatfield_correction.utils.utils import (
     extract_channel_from_tile_name,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class IOConcurrencyConfig(BaseModel):
+    """Per-worker concurrency limits for the Zarr/TensorStore I/O backends.
+
+    Each field maps 1:1 to ``zarr_io.config.IOConcurrencyConfig``. Limits apply
+    per Dask worker process, so the effective cluster-wide concurrency is roughly
+    ``num_workers`` times these values. Set a field to ``null`` to fall back to the
+    backend library's built-in default for that limit.
+    """
+
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    zarr_async_concurrency: int | None = Field(
+        default=4,
+        ge=1,
+        description="Zarr async I/O concurrency limit (zarr backend).",
+    )
+    zarr_threading_max_workers: int | None = Field(
+        default=4,
+        ge=1,
+        description="Zarr internal thread-pool worker limit (zarr backend).",
+    )
+    tensorstore_data_copy_concurrency: int | None = Field(
+        default=4,
+        ge=1,
+        description="TensorStore data-copy concurrency limit (tensorstore backend).",
+    )
+    tensorstore_file_io_concurrency: int | None = Field(
+        default=4,
+        ge=1,
+        description="TensorStore file I/O concurrency limit (tensorstore backend).",
+    )
+    tensorstore_s3_request_concurrency: int | None = Field(
+        default=4,
+        ge=1,
+        description="TensorStore S3 request concurrency limit (tensorstore backend).",
+    )
+    tensorstore_http_request_concurrency: int | None = Field(
+        default=4,
+        ge=1,
+        description="TensorStore HTTP request concurrency limit (tensorstore backend).",
+    )
+
+    def to_io_concurrency(self) -> _ZarrIOConcurrencyConfig:
+        """Convert to the ``zarr_io`` dataclass consumed by the I/O backends."""
+        return _ZarrIOConcurrencyConfig(**self.model_dump())
 
 
 class PipelineConfig(BaseModel):
@@ -101,6 +150,13 @@ class PipelineConfig(BaseModel):
             "Backend used for Zarr reads/writes. 'tensorstore' is faster on S3; "
             "'zarr' uses zarr-python. Sparse mask/probability writes "
             "(write_empty_chunks=False) always use the zarr backend."
+        ),
+    )
+    io_concurrency: IOConcurrencyConfig = Field(
+        default_factory=IOConcurrencyConfig,
+        description=(
+            "Per-worker concurrency limits applied to the I/O backend for reads "
+            "and writes (see IOConcurrencyConfig)."
         ),
     )
     output_zarr_format: Literal["match", "2", "3"] = Field(

--- a/code/exaspim_flatfield_correction/config.py
+++ b/code/exaspim_flatfield_correction/config.py
@@ -37,12 +37,12 @@ class IOConcurrencyConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", validate_assignment=True)
 
     zarr_async_concurrency: int | None = Field(
-        default=4,
+        default=8,
         ge=1,
         description="Zarr async I/O concurrency limit (zarr backend).",
     )
     zarr_threading_max_workers: int | None = Field(
-        default=4,
+        default=8,
         ge=1,
         description="Zarr internal thread-pool worker limit (zarr backend).",
     )

--- a/code/exaspim_flatfield_correction/config.py
+++ b/code/exaspim_flatfield_correction/config.py
@@ -159,6 +159,17 @@ class PipelineConfig(BaseModel):
             "and writes (see IOConcurrencyConfig)."
         ),
     )
+    max_chunks_per_block: int = Field(
+        default=32768,
+        ge=1,
+        description=(
+            "Maximum chunks written per dask.compute when storing arrays. Large "
+            "arrays (e.g. the full-resolution mask and corrected output) are "
+            "written in chunk-aligned slabs of at most this many chunks so the "
+            "Dask scheduler isn't overwhelmed materializing one giant task graph. "
+            "Forwarded to zarr_io.write_dask_array via store_ome_zarr."
+        ),
+    )
     output_zarr_format: Literal["match", "2", "3"] = Field(
         default="match",
         description=(

--- a/code/exaspim_flatfield_correction/config.py
+++ b/code/exaspim_flatfield_correction/config.py
@@ -95,6 +95,28 @@ class PipelineConfig(BaseModel):
         ge=1,
         description="Number of OME-Zarr pyramid levels to write.",
     )
+    io_backend: Literal["tensorstore", "zarr"] = Field(
+        default="tensorstore",
+        description=(
+            "Backend used for Zarr reads/writes. 'tensorstore' is faster on S3; "
+            "'zarr' uses zarr-python. Sparse mask/probability writes "
+            "(write_empty_chunks=False) always use the zarr backend."
+        ),
+    )
+    output_zarr_format: Literal["match", "2", "3"] = Field(
+        default="match",
+        description=(
+            "Zarr format for corrected/mask/probability outputs. 'match' uses "
+            "the input tile's format (v2 or v3); '2' or '3' force a format."
+        ),
+    )
+    corrected_rank: int = Field(
+        default=-2,
+        description=(
+            "Rank passed to windowed_rank when downsampling the corrected and "
+            "probability volumes (-2 is the second brightest voxel); masks use windowed_mode."
+        ),
+    )
     use_reference_bkg: bool = Field(
         default=False,
         description="Use a reference background image instead of estimating.",

--- a/code/exaspim_flatfield_correction/fitting.py
+++ b/code/exaspim_flatfield_correction/fitting.py
@@ -510,8 +510,13 @@ def calc_percentile_weight(
             # block is normalized t
             # compute exponent part
             z = -B * np.clip(block, 0.0, 1.0)
-            # compute (1 + Q exp(z))^(−1/nu); z is <= 0 so exp(z) is stable
-            return (1.0 / (1.0 + Q * np.exp(z))) ** (1.0 / nu)
+            # compute (1 + Q exp(z))^(−1/nu); z is <= 0 so exp(z) is stable.
+            # Cast back to float32: under NEP 50, the np.float64 scalar ``B``
+            # promotes the float32 block to float64, which would otherwise
+            # violate the dtype=np.float32 declared on map_blocks below and
+            # leak float64 chunks into the float32 output store.
+            out = (1.0 / (1.0 + Q * np.exp(z))) ** (1.0 / nu)
+            return out.astype(np.float32, copy=False)
 
         weights = da.map_blocks(_richards, t, dtype=np.float32)
 

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -627,7 +627,7 @@ def _create_mask_artifacts(
             zarr_format=3,
             io_backend=io_backend,
             reducer=partial(windowed_rank, rank=corrected_rank),
-            write_empty_chunks=False,
+            write_empty_chunks=True,
             max_chunks_per_block=max_chunks_per_block,
             output_shards=probability_shards,
         )
@@ -772,7 +772,7 @@ def flatfield_fitting(
         zarr_format=3,
         io_backend=io_backend,
         reducer=windowed_mode,
-        write_empty_chunks=False,
+        write_empty_chunks=True,
         max_chunks_per_block=max_chunks_per_block,
         output_shards=mask_shards,
     )

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -7,14 +7,12 @@ import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import zarr
-from numcodecs import blosc
-
-blosc.use_threads = False
 import dask.array as da
 import tifffile
 from dask.distributed import performance_report
@@ -61,11 +59,14 @@ from exaspim_flatfield_correction.utils.utils import (
     weighted_percentile,
 )
 from exaspim_flatfield_correction.utils.zarr_utils import (
-    initialize_zarr_group,
+    ensure_group,
     parse_ome_zarr_transformations,
     store_ome_zarr,
 )
 from exaspim_flatfield_correction.utils.dask_utils import create_dask_client
+from xarray_multiscale.reducers import windowed_mode, windowed_rank
+from zarr_io.arrays import open_group, read_zarr_array
+from zarr_io.config import IOBackendName
 
 
 logging.basicConfig(
@@ -83,10 +84,43 @@ class MaskArtifacts:
     probability_volume: da.Array | None = None
 
 
+def _save_local_zarr(
+    path: str, array: np.ndarray, chunks: tuple[int, ...]
+) -> str:
+    """Write a numpy array to a local Zarr array (overwriting).
+
+    Used for ephemeral, local-only caches (background images, preprocessed
+    masks). Uses the default Zarr v3 zstd compressor; reads use ``da.from_zarr``.
+    """
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    z_arr = zarr.create_array(
+        store=str(path),
+        shape=tuple(int(s) for s in array.shape),
+        dtype=array.dtype,
+        chunks=tuple(int(c) for c in chunks),
+    )
+    z_arr[...] = array
+    return str(path)
+
+
+def resolve_output_format(args: PipelineConfig) -> int:
+    """Resolve the output Zarr format (2 or 3) from config and the input tile.
+
+    ``output_zarr_format="match"`` reads the first input tile's format so the
+    corrected output round-trips in the same Zarr format as the input.
+    """
+    preference = args.output_zarr_format
+    if preference in ("2", "3"):
+        return int(preference)
+    first_tile = open_group(args.tile_paths[0], mode="r")
+    return int(first_tile.metadata.zarr_format)
+
+
 def background_subtraction(
     tile_path: str,
     full_res: da.Array,
-    z: zarr.hierarchy.Group,
+    z: zarr.Group,
     results_dir: str | None = None,
     tile_name: str | None = None,
     is_binned_channel: bool = False,
@@ -94,6 +128,7 @@ def background_subtraction(
     background_smoothing_sigma: float = 1.0,
     background_final_smoothing_sigma: float = 0.0,
     target_resolution: str = "0",
+    io_backend: IOBackendName = "tensorstore",
 ) -> tuple[da.Array, np.ndarray, np.ndarray | None, Path | None]:
     """Remove background estimates from the full-resolution volume.
 
@@ -103,7 +138,7 @@ def background_subtraction(
         Filesystem or S3 path to the tile Zarr group.
     full_res : dask.array.Array
         Full-resolution image volume to correct (modified lazily).
-    z : zarr.hierarchy.Group
+    z : zarr.Group
         Open Zarr hierarchy for the tile.
     results_dir : str or None, default=None
         Directory where the temporary background Zarr cache should be written.
@@ -166,9 +201,8 @@ def background_subtraction(
             "Background estimation smoothing sigma: %s",
             background_smoothing_sigma,
         )
-        low_res = da.from_zarr(
-            z[bkg_res],
-            name=f"bkg-selector-{safe_tile_name}-{bkg_res}-{dask_name_token}",
+        low_res = read_zarr_array(
+            z, component=bkg_res, io_backend=io_backend
         ).squeeze().astype(np.float32)
         low_res_shape = tuple(int(dim) for dim in low_res.shape)
         if background_smoothing_sigma > 0:
@@ -265,14 +299,7 @@ def _write_background_cache(
 ) -> Path:
     """Write a 2D background image to a local chunked Zarr array."""
 
-    if cache_path.exists():
-        shutil.rmtree(cache_path)
-    zarr.save_array(
-        str(cache_path),
-        np.asarray(bkg, dtype=np.float32),
-        chunks=chunks,
-        compressor=blosc.Blosc(cname="zstd", clevel=1),
-    )
+    _save_local_zarr(str(cache_path), np.asarray(bkg, dtype=np.float32), chunks)
     return cache_path
 
 
@@ -329,7 +356,7 @@ def flatfield_reference(full_res: da.Array, flatfield_path: str) -> da.Array:
 
 def flatfield_basicpy(
     full_res: da.Array,
-    z: zarr.hierarchy.Group,
+    z: zarr.Group,
     is_binned_channel: bool,
     bkg: np.ndarray | None = None,
     mask_dir: str | None = None,
@@ -340,6 +367,7 @@ def flatfield_basicpy(
     shuffle_frames: bool = False,
     autotune: bool = False,
     results_dir: str | None = None,
+    io_backend: IOBackendName = "tensorstore",
 ) -> da.Array:
     """Apply BasicPy flatfield correction to the supplied volume.
 
@@ -347,7 +375,7 @@ def flatfield_basicpy(
     ----------
     full_res : dask.array.Array
         Full-resolution image volume to correct.
-    z : zarr.hierarchy.Group
+    z : zarr.Group
         Zarr hierarchy for the tile.
     is_binned_channel : bool
         ``True`` when processing the binned channel.
@@ -376,7 +404,9 @@ def flatfield_basicpy(
         Lazily evaluated corrected volume.
     """
     basicpy_res = "0" if is_binned_channel else "3"
-    low_res = da.from_zarr(z[basicpy_res]).squeeze().astype(np.float32)
+    low_res = read_zarr_array(
+        z, component=basicpy_res, io_backend=io_backend
+    ).squeeze().astype(np.float32)
     if bkg is not None:
         low_res = subtract_bkg(
             low_res,
@@ -444,18 +474,13 @@ def _preprocess_mask(
             chunks=chunks,
         ).compute()
     mask = mask.astype(np.uint8)
-    zarr.save_array(
-        str(mask_name),
-        mask,
-        chunks=chunks,
-        compressor=blosc.Blosc(cname="zstd", clevel=1),
-    )
+    _save_local_zarr(str(mask_name), mask, chunks)
     return da.from_zarr(mask_name)
 
 
 def _create_mask_artifacts(
     low_res: da.Array,
-    z: zarr.hierarchy.Group,
+    z: zarr.Group,
     fitting_res: str,
     mask_dir: str,
     tile_name: str,
@@ -464,6 +489,9 @@ def _create_mask_artifacts(
     bkg_slice_indices: np.ndarray,
     out_probability_path: str,
     overwrite: bool,
+    output_zarr_format: int = 2,
+    io_backend: IOBackendName = "tensorstore",
+    corrected_rank: int = -2,
 ) -> MaskArtifacts:
     """Generate mask artifacts and optional probability volumes for a tile.
 
@@ -471,7 +499,7 @@ def _create_mask_artifacts(
     ----------
     low_res : dask.array.Array
         Low-resolution stack used for mask inference.
-    z : zarr.hierarchy.Group
+    z : zarr.Group
         Zarr hierarchy that contains the tile data.
     fitting_res : str
         Resolution key within ``z`` from which the mask is derived.
@@ -554,11 +582,14 @@ def _create_mask_artifacts(
             tuple(probability_scale[-3:]),
             tuple(probability_translation),
             overwrite=overwrite,
+            zarr_format=output_zarr_format,
+            io_backend=io_backend,
+            reducer=partial(windowed_rank, rank=corrected_rank),
             write_empty_chunks=False,
         )
         # Do not materialize into memory until needed
-        probability_volume = da.from_zarr(
-            probability_path, component="0"
+        probability_volume = read_zarr_array(
+            probability_path, component="0", io_backend=io_backend
         ).squeeze()
 
     return MaskArtifacts(
@@ -569,7 +600,7 @@ def _create_mask_artifacts(
 
 def flatfield_fitting(
     full_res: da.Array,
-    z: zarr.hierarchy.Group,
+    z: zarr.Group,
     is_binned_channel: bool,
     mask_dir: str,
     tile_name: str,
@@ -583,6 +614,9 @@ def flatfield_fitting(
     bkg_slice_indices: np.ndarray,
     results_dir: str | None = None,
     mask_artifacts: MaskArtifacts | None = None,
+    output_zarr_format: int = 2,
+    io_backend: IOBackendName = "tensorstore",
+    corrected_rank: int = -2,
 ) -> tuple[da.Array, dict[str, np.ndarray], MaskArtifacts | None]:
     """Run the fitting-based flatfield workflow for a single tile.
 
@@ -590,7 +624,7 @@ def flatfield_fitting(
     ----------
     full_res : dask.array.Array
         Full-resolution volume to correct.
-    z : zarr.hierarchy.Group
+    z : zarr.Group
         Zarr hierarchy that stores the tile data.
     is_binned_channel : bool
         Indicates whether the tile corresponds to the binned channel.
@@ -627,7 +661,9 @@ def flatfield_fitting(
         ``axis_fits`` maps ``{"x", "y", "z"}`` to their correction curves.
     """
     fitting_res = "0" if is_binned_channel else "3"
-    low_res = da.from_zarr(z[fitting_res]).squeeze().astype(np.float32)
+    low_res = read_zarr_array(
+        z, component=fitting_res, io_backend=io_backend
+    ).squeeze().astype(np.float32)
 
     low_res = subtract_bkg(
         low_res,
@@ -649,6 +685,9 @@ def flatfield_fitting(
             bkg_slice_indices=bkg_slice_indices,
             out_probability_path=out_probability_path,
             overwrite=overwrite,
+            output_zarr_format=output_zarr_format,
+            io_backend=io_backend,
+            corrected_rank=corrected_rank,
         )
     else:
         _LOGGER.info(
@@ -679,10 +718,15 @@ def flatfield_fitting(
         coordinate_transformations["scale"][-3:],
         coordinate_transformations["translation"],
         overwrite=overwrite,
+        zarr_format=output_zarr_format,
+        io_backend=io_backend,
+        reducer=windowed_mode,
         write_empty_chunks=False,
     )
     # Re-read the computed mask back from S3 for performance
-    mask_upscaled = da.from_zarr(mask_path, component="0").squeeze()
+    mask_upscaled = read_zarr_array(
+        mask_path, component="0", io_backend=io_backend
+    ).squeeze()
 
     med_factor = (
         config.med_factor_binned
@@ -876,6 +920,7 @@ def process_tile(
     fitting_config: FittingConfig | None,
     median_summary: dict[str, float],
     mask_artifacts: MaskArtifacts | None,
+    output_format: int,
 ) -> MaskArtifacts | None:
     """Execute the flatfield pipeline for a single tile and persist outputs."""
 
@@ -895,7 +940,7 @@ def process_tile(
                 )
             _LOGGER.info(f"{tile_name} is binned: {is_binned_channel}")
 
-            z = zarr.open(tile_path, mode="r")
+            z = open_group(tile_path, mode="r")
             coordinate_transformations = parse_ome_zarr_transformations(
                 z, resolution
             )
@@ -903,12 +948,8 @@ def process_tile(
                 f"Coordinate transformations: {coordinate_transformations}"
             )
 
-            full_res = da.from_zarr(
-                z[resolution],
-                name=(
-                    f"input-{_safe_dask_name(tile_name)}-{resolution}-"
-                    f"{uuid.uuid4().hex}"
-                ),
+            full_res = read_zarr_array(
+                z, component=resolution, io_backend=args.io_backend
             ).squeeze().astype(np.float32)
             _LOGGER.info(f"Full resolution array shape: {full_res.shape}")
 
@@ -934,6 +975,7 @@ def process_tile(
                         args.background_final_smoothing_sigma
                     ),
                     target_resolution=resolution,
+                    io_backend=args.io_backend,
                 )
 
             axis_fits = None
@@ -951,6 +993,7 @@ def process_tile(
                         args.mask_dir,
                         tile_name,
                         results_dir=results_dir,
+                        io_backend=args.io_backend,
                     )
                 elif method == "fitting":
                     if fitting_config is None:
@@ -985,6 +1028,9 @@ def process_tile(
                         bkg=bkg,
                         bkg_slice_indices=bkg_slice_indices,
                         mask_artifacts=mask_artifacts,
+                        output_zarr_format=output_format,
+                        io_backend=args.io_backend,
+                        corrected_rank=args.corrected_rank,
                     )
                 else:
                     _LOGGER.error(f"Invalid method: {method}")
@@ -1004,6 +1050,9 @@ def process_tile(
                 coordinate_transformations["scale"][-3:],
                 coordinate_transformations["translation"],
                 overwrite=args.overwrite,
+                zarr_format=output_format,
+                io_backend=args.io_backend,
+                reducer=partial(windowed_rank, rank=args.corrected_rank),
                 write_empty_chunks=True,
             )
             _LOGGER.info(f"Storing OME-Zarr took {time.time() - t0:.2f}s")
@@ -1118,10 +1167,13 @@ def main() -> None:
     )
     _LOGGER.info(f"Dask client: {client}")
 
+    output_format = resolve_output_format(args)
+    _LOGGER.info("Output Zarr format: v%d", output_format)
+
     out_mask_path = create_zarr_artifact_path(args.output, "mask")
     out_probability_path = create_zarr_artifact_path(args.output, "probability")
-    initialize_zarr_group(out_mask_path)
-    initialize_zarr_group(out_probability_path)
+    ensure_group(out_mask_path, zarr_format=output_format)
+    ensure_group(out_probability_path, zarr_format=output_format)
 
     artifacts_destination = None
     tile_name_for_artifacts = (
@@ -1184,6 +1236,7 @@ def main() -> None:
             fitting_config=fitting_config,
             median_summary=median_summary,
             mask_artifacts=mask_artifacts,
+            output_format=output_format,
         )
 
     if artifacts_destination:

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -3,8 +3,10 @@ import json
 import logging
 import os
 import shutil
+import sys
 import time
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from functools import partial
@@ -79,6 +81,37 @@ logging.basicConfig(
     datefmt="%d-%b-%y %H:%M:%S",
 )
 _LOGGER = logging.getLogger(__name__)
+
+
+@contextmanager
+def safe_performance_report(filename: str):
+    """Wrap dask's ``performance_report`` so a report-rendering failure never
+    aborts a completed run.
+
+    The performance report is pure diagnostics, but it is generated in the
+    context manager's ``__exit__`` -- i.e. *after* all tile work has finished.
+    bokeh/distributed version skew (e.g. bokeh>=3.9 renaming ``file.html`` to
+    ``file.html.jinja``, which distributed 2024.11.2 still extends) raises a
+    ``TemplateNotFound`` there, which would otherwise discard hours of finished
+    work. Any error writing the report is logged and swallowed; genuine errors
+    from the wrapped body still propagate.
+    """
+    report = performance_report(filename=filename)
+    report.__enter__()
+    exc_info = (None, None, None)
+    try:
+        yield
+    except BaseException:
+        exc_info = sys.exc_info()
+        raise
+    finally:
+        try:
+            report.__exit__(*exc_info)
+        except Exception as report_exc:  # noqa: BLE001
+            _LOGGER.warning(
+                f"Failed to write dask performance report to {filename}: "
+                f"{report_exc}"
+            )
 
 
 @dataclass
@@ -945,7 +978,7 @@ def process_tile(
     report_path = os.path.join(results_dir, f"dask-report_{tile_name}.html")
     background_cache_path: Path | None = None
 
-    with performance_report(filename=report_path):
+    with safe_performance_report(filename=report_path):
         try:
             if args.is_binned:
                 is_binned_channel = True

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -73,7 +73,7 @@ from zarr_io.backends import (
     configure_io_backend_on_dask_workers,
     io_backend_from_name,
 )
-from zarr_io.config import IOBackendName
+from zarr_io.config import IOBackendName, OutputShards
 
 
 logging.basicConfig(
@@ -531,6 +531,7 @@ def _create_mask_artifacts(
     io_backend: IOBackendName | ArrayIOBackend = "tensorstore",
     corrected_rank: int = -2,
     max_chunks_per_block: int | None = 16384,
+    mask_shards: OutputShards = "none",
 ) -> MaskArtifacts:
     """Generate mask artifacts and optional probability volumes for a tile.
 
@@ -621,11 +622,14 @@ def _create_mask_artifacts(
             tuple(probability_scale[-3:]),
             tuple(probability_translation),
             overwrite=overwrite,
-            zarr_format=output_zarr_format,
+            # Always Zarr v3 so the sparse, highly-compressed probability volume
+            # can be sharded (many tiny chunks -> one shard object on S3).
+            zarr_format=3,
             io_backend=io_backend,
             reducer=partial(windowed_rank, rank=corrected_rank),
             write_empty_chunks=False,
             max_chunks_per_block=max_chunks_per_block,
+            output_shards=mask_shards,
         )
         # Do not materialize into memory until needed
         probability_volume = read_zarr_array(
@@ -658,6 +662,7 @@ def flatfield_fitting(
     io_backend: IOBackendName | ArrayIOBackend = "tensorstore",
     corrected_rank: int = -2,
     max_chunks_per_block: int | None = 16384,
+    mask_shards: OutputShards = "none",
 ) -> tuple[da.Array, dict[str, np.ndarray], MaskArtifacts | None]:
     """Run the fitting-based flatfield workflow for a single tile.
 
@@ -730,6 +735,7 @@ def flatfield_fitting(
             io_backend=io_backend,
             corrected_rank=corrected_rank,
             max_chunks_per_block=max_chunks_per_block,
+            mask_shards=mask_shards,
         )
     else:
         _LOGGER.info(
@@ -760,11 +766,14 @@ def flatfield_fitting(
         coordinate_transformations["scale"][-3:],
         coordinate_transformations["translation"],
         overwrite=overwrite,
-        zarr_format=output_zarr_format,
+        # Always Zarr v3 so the sparse, highly-compressed upscaled mask can be
+        # sharded (many tiny chunks -> one shard object on S3).
+        zarr_format=3,
         io_backend=io_backend,
         reducer=windowed_mode,
         write_empty_chunks=False,
         max_chunks_per_block=max_chunks_per_block,
+        output_shards=mask_shards,
     )
     # Re-read the computed mask back from S3 for performance
     mask_upscaled = read_zarr_array(
@@ -969,6 +978,19 @@ def process_tile(
 
     tile_name = Path(tile_path).name
     _LOGGER.info(f"Processing tile: {tile_name}")
+    # Shard layout (TCZYX) for the always-v3 sparse mask/probability writes;
+    # "none" disables sharding. mask_shard_size is ZYX, front-padded with (1, 1).
+    mask_shards: OutputShards = (
+        (1, 1, *args.mask_shard_size) if args.mask_shard_size else "none"
+    )
+    # Shard layout for the dense corrected output. Sharding is Zarr v3 only, so
+    # only apply a shard tuple when the output format is v3; for v2 a shard tuple
+    # would be rejected by the array spec / pyramid writer.
+    corrected_shards: OutputShards = (
+        (1, 1, *args.corrected_shard_size)
+        if (args.corrected_shard_size and output_format == 3)
+        else "none"
+    )
     # Build the I/O backend once with the configured concurrency limits baked in.
     # Threading the backend object (rather than the backend name) makes both reads
     # and writes honor IOConcurrencyConfig, including across pickled Dask tasks.
@@ -1081,6 +1103,7 @@ def process_tile(
                         io_backend=io_backend,
                         corrected_rank=args.corrected_rank,
                         max_chunks_per_block=args.max_chunks_per_block,
+                        mask_shards=mask_shards,
                     )
                 else:
                     _LOGGER.error(f"Invalid method: {method}")
@@ -1105,6 +1128,7 @@ def process_tile(
                 reducer=partial(windowed_rank, rank=args.corrected_rank),
                 write_empty_chunks=True,
                 max_chunks_per_block=args.max_chunks_per_block,
+                output_shards=corrected_shards,
             )
             _LOGGER.info(f"Storing OME-Zarr took {time.time() - t0:.2f}s")
 
@@ -1231,8 +1255,11 @@ def main() -> None:
 
     out_mask_path = create_zarr_artifact_path(args.output, "mask")
     out_probability_path = create_zarr_artifact_path(args.output, "probability")
-    ensure_group(out_mask_path, zarr_format=output_format)
-    ensure_group(out_probability_path, zarr_format=output_format)
+    # The sparse mask/probability arrays are always written as Zarr v3 (so they
+    # can be sharded), so their parent groups must be v3 too, regardless of the
+    # corrected output's format.
+    ensure_group(out_mask_path, zarr_format=3)
+    ensure_group(out_probability_path, zarr_format=3)
 
     artifacts_destination = None
     tile_name_for_artifacts = (

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -652,7 +652,6 @@ def flatfield_fitting(
     out_probability_path: str,
     coordinate_transformations: dict[str, Any],
     overwrite: bool,
-    n_levels: int,
     config: FittingConfig,
     bkg: np.ndarray,
     bkg_slice_indices: np.ndarray,
@@ -687,8 +686,6 @@ def flatfield_fitting(
         Transformation metadata copied into the OME-NGFF output.
     overwrite : bool
         Whether existing OME-Zarr outputs may be replaced.
-    n_levels : int
-        Number of pyramid levels to generate for outputs.
     config : FittingConfig
         Configuration controlling fitting behaviour and thresholds.
     bkg : numpy.ndarray
@@ -760,10 +757,16 @@ def flatfield_fitting(
         )
 
     mask_path = out_mask_path.rstrip("/") + f"/{tile_name}"
+    # Write only the channel's full-resolution mask as a single OME-Zarr level
+    # (no multiscale pyramid). The fitting mask is upscaled to full resolution for
+    # the unbinned channel and used as-is for the binned channel (which is natively
+    # ~8x downsampled, so its level 0 already matches the unbinned level 3). This
+    # single-level, full-resolution mask is the only array downstream consumes, so
+    # generating the pyramid would be wasted work.
     store_ome_zarr(
         mask_upscaled.astype(np.uint8),
         mask_path,
-        n_levels,
+        1,
         coordinate_transformations["scale"][-3:],
         coordinate_transformations["translation"],
         overwrite=overwrite,
@@ -1102,7 +1105,6 @@ def process_tile(
                         out_probability_path,
                         coordinate_transformations,
                         args.overwrite,
-                        args.n_levels,
                         fitting_config,
                         results_dir=results_dir,
                         bkg=bkg,

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -66,6 +66,11 @@ from exaspim_flatfield_correction.utils.zarr_utils import (
 from exaspim_flatfield_correction.utils.dask_utils import create_dask_client
 from xarray_multiscale.reducers import windowed_mode, windowed_rank
 from zarr_io.arrays import open_group, read_zarr_array
+from zarr_io.backends import (
+    ArrayIOBackend,
+    configure_io_backend_on_dask_workers,
+    io_backend_from_name,
+)
 from zarr_io.config import IOBackendName
 
 
@@ -128,7 +133,7 @@ def background_subtraction(
     background_smoothing_sigma: float = 1.0,
     background_final_smoothing_sigma: float = 0.0,
     target_resolution: str = "0",
-    io_backend: IOBackendName = "tensorstore",
+    io_backend: IOBackendName | ArrayIOBackend = "tensorstore",
 ) -> tuple[da.Array, np.ndarray, np.ndarray | None, Path | None]:
     """Remove background estimates from the full-resolution volume.
 
@@ -367,7 +372,7 @@ def flatfield_basicpy(
     shuffle_frames: bool = False,
     autotune: bool = False,
     results_dir: str | None = None,
-    io_backend: IOBackendName = "tensorstore",
+    io_backend: IOBackendName | ArrayIOBackend = "tensorstore",
 ) -> da.Array:
     """Apply BasicPy flatfield correction to the supplied volume.
 
@@ -490,7 +495,7 @@ def _create_mask_artifacts(
     out_probability_path: str,
     overwrite: bool,
     output_zarr_format: int = 2,
-    io_backend: IOBackendName = "tensorstore",
+    io_backend: IOBackendName | ArrayIOBackend = "tensorstore",
     corrected_rank: int = -2,
 ) -> MaskArtifacts:
     """Generate mask artifacts and optional probability volumes for a tile.
@@ -615,7 +620,7 @@ def flatfield_fitting(
     results_dir: str | None = None,
     mask_artifacts: MaskArtifacts | None = None,
     output_zarr_format: int = 2,
-    io_backend: IOBackendName = "tensorstore",
+    io_backend: IOBackendName | ArrayIOBackend = "tensorstore",
     corrected_rank: int = -2,
 ) -> tuple[da.Array, dict[str, np.ndarray], MaskArtifacts | None]:
     """Run the fitting-based flatfield workflow for a single tile.
@@ -926,6 +931,12 @@ def process_tile(
 
     tile_name = Path(tile_path).name
     _LOGGER.info(f"Processing tile: {tile_name}")
+    # Build the I/O backend once with the configured concurrency limits baked in.
+    # Threading the backend object (rather than the backend name) makes both reads
+    # and writes honor IOConcurrencyConfig, including across pickled Dask tasks.
+    io_backend = io_backend_from_name(
+        args.io_backend, args.io_concurrency.to_io_concurrency()
+    )
     report_path = os.path.join(results_dir, f"dask-report_{tile_name}.html")
     background_cache_path: Path | None = None
 
@@ -949,7 +960,7 @@ def process_tile(
             )
 
             full_res = read_zarr_array(
-                z, component=resolution, io_backend=args.io_backend
+                z, component=resolution, io_backend=io_backend
             ).squeeze().astype(np.float32)
             _LOGGER.info(f"Full resolution array shape: {full_res.shape}")
 
@@ -975,7 +986,7 @@ def process_tile(
                         args.background_final_smoothing_sigma
                     ),
                     target_resolution=resolution,
-                    io_backend=args.io_backend,
+                    io_backend=io_backend,
                 )
 
             axis_fits = None
@@ -993,7 +1004,7 @@ def process_tile(
                         args.mask_dir,
                         tile_name,
                         results_dir=results_dir,
-                        io_backend=args.io_backend,
+                        io_backend=io_backend,
                     )
                 elif method == "fitting":
                     if fitting_config is None:
@@ -1029,7 +1040,7 @@ def process_tile(
                         bkg_slice_indices=bkg_slice_indices,
                         mask_artifacts=mask_artifacts,
                         output_zarr_format=output_format,
-                        io_backend=args.io_backend,
+                        io_backend=io_backend,
                         corrected_rank=args.corrected_rank,
                     )
                 else:
@@ -1051,7 +1062,7 @@ def process_tile(
                 coordinate_transformations["translation"],
                 overwrite=args.overwrite,
                 zarr_format=output_format,
-                io_backend=args.io_backend,
+                io_backend=io_backend,
                 reducer=partial(windowed_rank, rank=args.corrected_rank),
                 write_empty_chunks=True,
             )
@@ -1166,6 +1177,14 @@ def main() -> None:
         worker_mode=args.worker_mode,
     )
     _LOGGER.info(f"Dask client: {client}")
+
+    # Propagate Zarr concurrency limits to every worker process. This is a no-op
+    # for the tensorstore backend (whose limits travel with the pickled backend
+    # object) but is required for the zarr backend, whose zarr.config must be set
+    # on the workers themselves rather than only in the client process.
+    configure_io_backend_on_dask_workers(
+        client, args.io_backend, args.io_concurrency.to_io_concurrency()
+    )
 
     output_format = resolve_output_format(args)
     _LOGGER.info("Output Zarr format: v%d", output_format)

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -531,7 +531,7 @@ def _create_mask_artifacts(
     io_backend: IOBackendName | ArrayIOBackend = "tensorstore",
     corrected_rank: int = -2,
     max_chunks_per_block: int | None = 16384,
-    mask_shards: OutputShards = "none",
+    probability_shards: OutputShards = "none",
 ) -> MaskArtifacts:
     """Generate mask artifacts and optional probability volumes for a tile.
 
@@ -629,7 +629,7 @@ def _create_mask_artifacts(
             reducer=partial(windowed_rank, rank=corrected_rank),
             write_empty_chunks=False,
             max_chunks_per_block=max_chunks_per_block,
-            output_shards=mask_shards,
+            output_shards=probability_shards,
         )
         # Do not materialize into memory until needed
         probability_volume = read_zarr_array(
@@ -663,6 +663,7 @@ def flatfield_fitting(
     corrected_rank: int = -2,
     max_chunks_per_block: int | None = 16384,
     mask_shards: OutputShards = "none",
+    probability_shards: OutputShards = "none",
 ) -> tuple[da.Array, dict[str, np.ndarray], MaskArtifacts | None]:
     """Run the fitting-based flatfield workflow for a single tile.
 
@@ -735,7 +736,7 @@ def flatfield_fitting(
             io_backend=io_backend,
             corrected_rank=corrected_rank,
             max_chunks_per_block=max_chunks_per_block,
-            mask_shards=mask_shards,
+            probability_shards=probability_shards,
         )
     else:
         _LOGGER.info(
@@ -983,6 +984,14 @@ def process_tile(
     mask_shards: OutputShards = (
         (1, 1, *args.mask_shard_size) if args.mask_shard_size else "none"
     )
+    # The probability volume is float32 (and full-res for binned channels), so it
+    # gets its own, smaller shard than the uint8 mask to keep each write task
+    # within the per-worker memory budget. Always v3, so no format guard.
+    probability_shards: OutputShards = (
+        (1, 1, *args.probability_shard_size)
+        if args.probability_shard_size
+        else "none"
+    )
     # Shard layout for the dense corrected output. Sharding is Zarr v3 only, so
     # only apply a shard tuple when the output format is v3; for v2 a shard tuple
     # would be rejected by the array spec / pyramid writer.
@@ -1104,6 +1113,7 @@ def process_tile(
                         corrected_rank=args.corrected_rank,
                         max_chunks_per_block=args.max_chunks_per_block,
                         mask_shards=mask_shards,
+                        probability_shards=probability_shards,
                     )
                 else:
                     _LOGGER.error(f"Invalid method: {method}")

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -497,6 +497,7 @@ def _create_mask_artifacts(
     output_zarr_format: int = 2,
     io_backend: IOBackendName | ArrayIOBackend = "tensorstore",
     corrected_rank: int = -2,
+    max_chunks_per_block: int | None = 16384,
 ) -> MaskArtifacts:
     """Generate mask artifacts and optional probability volumes for a tile.
 
@@ -591,6 +592,7 @@ def _create_mask_artifacts(
             io_backend=io_backend,
             reducer=partial(windowed_rank, rank=corrected_rank),
             write_empty_chunks=False,
+            max_chunks_per_block=max_chunks_per_block,
         )
         # Do not materialize into memory until needed
         probability_volume = read_zarr_array(
@@ -622,6 +624,7 @@ def flatfield_fitting(
     output_zarr_format: int = 2,
     io_backend: IOBackendName | ArrayIOBackend = "tensorstore",
     corrected_rank: int = -2,
+    max_chunks_per_block: int | None = 16384,
 ) -> tuple[da.Array, dict[str, np.ndarray], MaskArtifacts | None]:
     """Run the fitting-based flatfield workflow for a single tile.
 
@@ -693,6 +696,7 @@ def flatfield_fitting(
             output_zarr_format=output_zarr_format,
             io_backend=io_backend,
             corrected_rank=corrected_rank,
+            max_chunks_per_block=max_chunks_per_block,
         )
     else:
         _LOGGER.info(
@@ -727,6 +731,7 @@ def flatfield_fitting(
         io_backend=io_backend,
         reducer=windowed_mode,
         write_empty_chunks=False,
+        max_chunks_per_block=max_chunks_per_block,
     )
     # Re-read the computed mask back from S3 for performance
     mask_upscaled = read_zarr_array(
@@ -1042,6 +1047,7 @@ def process_tile(
                         output_zarr_format=output_format,
                         io_backend=io_backend,
                         corrected_rank=args.corrected_rank,
+                        max_chunks_per_block=args.max_chunks_per_block,
                     )
                 else:
                     _LOGGER.error(f"Invalid method: {method}")
@@ -1065,6 +1071,7 @@ def process_tile(
                 io_backend=io_backend,
                 reducer=partial(windowed_rank, rank=args.corrected_rank),
                 write_empty_chunks=True,
+                max_chunks_per_block=args.max_chunks_per_block,
             )
             _LOGGER.info(f"Storing OME-Zarr took {time.time() - t0:.2f}s")
 

--- a/code/exaspim_flatfield_correction/utils/mask_utils.py
+++ b/code/exaspim_flatfield_correction/utils/mask_utils.py
@@ -167,6 +167,44 @@ def size_filter(
     return final_mask
 
 
+def _integer_upsample(
+    mask: da.Array,
+    factors: tuple[int, int, int],
+    output_chunks: Union[tuple, str],
+) -> da.Array:
+    """Nearest-neighbor upsample a 3D mask by exact integer per-axis factors.
+
+    Each output block is produced by ``np.repeat`` on the matching input block,
+    so the work is a memory-bandwidth-bound block copy rather than the general
+    coordinate interpolation of ``scipy.ndimage.affine_transform`` (which is
+    ~50-60x slower per voxel here). The input is first rechunked so every input
+    block maps cleanly onto one output block of ~``output_chunks``, keeping
+    intermediate chunks from ballooning by ``prod(factors)``.
+    """
+    fz, fy, fx = (int(f) for f in factors)
+    if isinstance(output_chunks, tuple) and len(output_chunks) == 3:
+        in_chunks = tuple(
+            max(1, int(oc) // f)
+            for oc, f in zip(output_chunks, (fz, fy, fx))
+        )
+    else:
+        # No explicit output chunking: target ~(128, 256, 256) output blocks.
+        in_chunks = (max(1, 128 // fz), max(1, 256 // fy), max(1, 256 // fx))
+
+    mask = mask.rechunk(in_chunks)
+    out_chunks = tuple(
+        tuple(cs * f for cs in axis)
+        for axis, f in zip(mask.chunks, (fz, fy, fx))
+    )
+
+    def _repeat_block(block: np.ndarray) -> np.ndarray:
+        return np.repeat(
+            np.repeat(np.repeat(block, fz, axis=0), fy, axis=1), fx, axis=2
+        )
+
+    return mask.map_blocks(_repeat_block, chunks=out_chunks, dtype=mask.dtype)
+
+
 def upscale_mask_nearest(
     mask: np.ndarray,
     new_shape: tuple[int, int, int],
@@ -174,7 +212,14 @@ def upscale_mask_nearest(
 ) -> da.Array:
     """
     Upscales a 3D binary mask to a new shape using nearest-neighbor
-    interpolation with an affine transform via Dask.
+    interpolation via Dask.
+
+    When ``new_shape`` is an exact integer multiple of ``mask.shape`` on every
+    axis, this uses a fast per-block ``np.repeat`` upsample. Otherwise it falls
+    back to an affine transform (``scipy.ndimage.affine_transform``, order 0).
+    The block-repeat path floors the source index (``o -> o // f``) while the
+    affine path rounds it, so their results differ only by a sub-block boundary
+    shift (identical foreground count); immaterial for a mask.
 
     Parameters
     ----------
@@ -191,12 +236,31 @@ def upscale_mask_nearest(
     dask.array.Array
         The upscaled mask as a Dask array.
     """
-    # Compute anisotropic per-axis scale factors
+    if not isinstance(mask, da.Array):
+        mask = da.from_array(
+            mask, chunks=chunks if isinstance(chunks, (int, tuple)) else "auto"
+        )
+
+    # Prefer the fast block-repeat path when the scaling is an exact integer on
+    # every axis (the common full-res case, e.g. res 3 -> res 0 is exactly 8x).
+    exact_integer = all(
+        new_shape[i] % mask.shape[i] == 0 and new_shape[i] >= mask.shape[i]
+        for i in range(3)
+    )
+    if exact_integer:
+        factors = tuple(new_shape[i] // mask.shape[i] for i in range(3))
+        return _integer_upsample(mask, factors, chunks)
+
+    # Non-integer scaling: fall back to nearest-neighbor affine interpolation.
     sz = new_shape[0] / mask.shape[0]
     sy = new_shape[1] / mask.shape[1]
     sx = new_shape[2] / mask.shape[2]
-
-    # Use nearest-neighbor interpolation (order=0)
+    _LOGGER.debug(
+        "Non-integer upscale factors (%.4f, %.4f, %.4f); using affine_transform",
+        sz,
+        sy,
+        sx,
+    )
     upscaled = resize_dask(
         mask, scale_factor=(sz, sy, sx), order=0, output_chunks=chunks
     )

--- a/code/exaspim_flatfield_correction/utils/zarr_utils.py
+++ b/code/exaspim_flatfield_correction/utils/zarr_utils.py
@@ -169,6 +169,22 @@ def store_ome_zarr(
         max(1, min(int(c), int(s))) for c, s in zip(chunks, data.shape)
     )
 
+    # Normalize an explicit shard request (Zarr v3). A 3-tuple is ZYX and is
+    # front-padded to TCZYX. Zarr v3 requires the shard shape to be a whole
+    # multiple of the inner chunk along every axis, and neither zarr-io nor
+    # zarr-multiscale enforces that, so snap each axis to the nearest chunk
+    # multiple (at least one chunk). The same shard is applied to every pyramid
+    # level; a shard larger than a level's shape is fine (one partial shard).
+    if zarr_format == 3 and isinstance(output_shards, tuple):
+        if len(output_shards) == 3:
+            output_shards = (1, 1, *output_shards)
+        if len(output_shards) != 5:
+            raise ValueError("output_shards must describe all five TCZYX axes")
+        output_shards = tuple(
+            max(c, max(1, round(s / c)) * c)
+            for s, c in zip(output_shards, chunks)
+        )
+
     backend = io_backend_from_name(io_backend, io_concurrency)
 
     if codec is None:

--- a/code/exaspim_flatfield_correction/utils/zarr_utils.py
+++ b/code/exaspim_flatfield_correction/utils/zarr_utils.py
@@ -195,6 +195,11 @@ def store_ome_zarr(
     }
     if zarr_format == 2:
         spec_kwargs["compressor"] = codec
+        # zarr-python defaults v2 arrays to the "." dimension separator; force
+        # "/" so chunks are nested (matching the AIND OME-Zarr convention and
+        # the pre-refactor output). The pyramid writer inherits this from the
+        # level-0 array via ArraySpec.from_zarr.
+        spec_kwargs["dimension_separator"] = "/"
     else:
         spec_kwargs["compressors"] = (codec,)
         spec_kwargs["shards"] = level0_shards

--- a/code/exaspim_flatfield_correction/utils/zarr_utils.py
+++ b/code/exaspim_flatfield_correction/utils/zarr_utils.py
@@ -1,307 +1,308 @@
+"""Zarr I/O and OME-Zarr multiscale writing for the flatfield pipeline.
+
+Reads and writes both Zarr v2 and Zarr v3 (OME-NGFF 0.4 / 0.5) by delegating to
+the ``zarr-io`` and ``zarr-multiscale`` libraries. The corrected output is written
+in the same Zarr format as the input tile (chosen by the caller).
+"""
+
 import logging
 from functools import partial
-from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 import dask.array as da
 import numpy as np
-import s3fs
 import zarr
-from aind_data_transfer.transformations.ome_zarr import (
-    downsample_and_store,
-    store_array,
+
+from xarray_multiscale import multiscale as _xarray_multiscale
+from xarray_multiscale.reducers import windowed_rank
+
+from zarr_io.arrays import (
+    ArraySpec,
+    ArrayTarget,
+    open_group,
+    read_zarr_array,
+    write_dask_array,
+)
+from zarr_io.backends import ArrayIOBackend, io_backend_from_name
+from zarr_io.config import IOBackendName, IOConcurrencyConfig, OutputShards
+from zarr_io.ome import (
+    axes_from_attrs,
+    parse_ome_zarr_transformations,  # re-exported for callers (v0.4 + v0.5 aware)
     write_ome_ngff_metadata,
 )
-from numcodecs import blosc
-from numcodecs.abc import Codec
-from zarr.errors import ContainsGroupError
-
-blosc.use_threads = False
-from xarray_multiscale.reducers import windowed_mean, windowed_rank
+from zarr_multiscale.pyramid import reducer_name, write_multiscale_pyramid
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_SCALE_FACTORS = (1, 1, 2, 2, 2)
+DEFAULT_REDUCER = partial(windowed_rank, rank=-2)
 
-def initialize_zarr_group(
+__all__ = [
+    "store_ome_zarr",
+    "parse_ome_zarr_transformations",
+    "ensure_group",
+    "get_zarr_tiles",
+]
+
+
+def ensure_group(
     path: str,
     *,
+    zarr_format: int,
     mode: str = "a",
     aws_region: str = "us-west-2",
     s3_use_ssl: bool = False,
-    s3_batch_size: int = 64,
-    s3_multipart_threshold: int = 256 * 1024 * 1024,
     s3_total_max_attempts: int = 10,
     s3_retry_mode: str = "adaptive",
-) -> zarr.hierarchy.Group:
-    """Open (and create if needed) a Zarr group.
+) -> zarr.Group:
+    """Open (creating if needed) a container Zarr group, local or on S3.
 
-    Parameters
-    ----------
-    path : str
-        Local filesystem path or S3 URI where the group should reside.
-    mode : str, optional
-        Zarr open mode to use (e.g. ``"a"``, ``"w"``, ``"w-"``). Defaults to
-        ``"a"`` which creates the group when missing and reuses it otherwise.
-    aws_region : str, optional
-        AWS region to use when ``path`` points to S3. Default "us-west-2".
-    s3_use_ssl : bool, optional
-        Whether to use SSL when communicating with S3. Default ``False``.
-    s3_batch_size : int, optional
-        Batch size for S3 multipart uploads. Default ``64``.
-    s3_multipart_threshold : int, optional
-        Threshold (in bytes) before S3 multipart uploads are used.
-        Default ``256 * 1024 * 1024`` (256 MB).
-    s3_total_max_attempts : int, optional
-        Maximum number of retry attempts for S3 operations. Default ``10``.
-    s3_retry_mode : str, optional
-        Retry mode passed to the S3 client. Default ``"adaptive"``.
-    Returns
-    -------
-    zarr.hierarchy.Group
-        The opened Zarr group handle.
+    Replaces the old ``initialize_zarr_group`` helper; supports both Zarr v2 and
+    v3 via ``zarr-io``.
     """
-
-    target_path = path.rstrip("/")
-    if target_path.startswith("s3://"):
-        s3 = s3fs.S3FileSystem(
-            anon=False,
-            client_kwargs={
-                "region_name": aws_region,
-            },
-            config_kwargs={
-                "s3": {
-                    "multipart_threshold": s3_multipart_threshold,
-                },
-                "retries": {
-                    "total_max_attempts": s3_total_max_attempts,
-                    "mode": s3_retry_mode,
-                },
-            },
-            use_ssl=s3_use_ssl,
-            s3_additional_kwargs={"batch_size": s3_batch_size},
-        )
-        store = s3fs.S3Map(root=target_path, s3=s3, check=False)
-    else:
-        Path(target_path).mkdir(parents=True, exist_ok=True)
-        store = zarr.DirectoryStore(target_path)
-    return zarr.open_group(store=store, mode=mode)
+    return open_group(
+        path,
+        mode=mode,
+        zarr_format=zarr_format,
+        aws_region=aws_region,
+        s3_use_ssl=s3_use_ssl,
+        s3_total_max_attempts=s3_total_max_attempts,
+        s3_retry_mode=s3_retry_mode,
+    )
 
 
 def store_ome_zarr(
-    corrected: da.Array,
+    data: da.Array,
     output_zarr: str,
     n_levels: int = 1,
     voxel_size: tuple[float, float, float] = (1.0, 1.0, 1.0),
-    origin: tuple[int, int, int, int, int] = (0, 0, 0, 0, 0),
+    origin: tuple[float, ...] = (0, 0, 0, 0, 0),
+    *,
     overwrite: bool = False,
-    reducer: Callable = windowed_mean,
-    aws_region: str = "us-west-2",
-    s3_use_ssl: bool = False,
+    zarr_format: int = 2,
+    io_backend: IOBackendName | ArrayIOBackend = "tensorstore",
+    io_concurrency: IOConcurrencyConfig | None = None,
+    reducer: Callable[..., Any] = DEFAULT_REDUCER,
     write_empty_chunks: bool = True,
     scale_factors: tuple[int, ...] | None = None,
-    block_shape: tuple[int, ...] | None = None,
-    codec: Codec | None = None,
-    s3_batch_size: int = 64,
-    s3_multipart_threshold: int = 256 * 1024 * 1024,
+    chunks: tuple[int, ...] | None = None,
+    output_shards: OutputShards = "none",
+    codec: Any | None = None,
+    aws_region: str = "us-west-2",
+    s3_use_ssl: bool = False,
     s3_total_max_attempts: int = 10,
     s3_retry_mode: str = "adaptive",
 ) -> None:
-    """
-    Store a Dask array as an OME-Zarr multiscale dataset, with optional S3
-    support and metadata.
+    """Store a Dask array as an OME-Zarr multiscale dataset (Zarr v2 or v3).
+
+    Writes level ``0`` directly, then generates pyramid levels ``1..n-1`` with
+    ``zarr-multiscale`` and writes OME-NGFF metadata. The output Zarr format is
+    chosen by ``zarr_format`` (match the input tile for round-trip compatibility).
 
     Parameters
     ----------
-    corrected : dask.array.Array
-        The image data to store (will be expanded to 5D if needed).
+    data : dask.array.Array
+        Image data to store (expanded to 5D TCZYX if needed).
     output_zarr : str
-        Path or S3 URL to the output zarr group.
-    n_levels : int, optional
-        Number of pyramid levels to generate. Default is 1.
-    voxel_size : tuple of float, optional
-        Physical voxel size (ZYX) for metadata. Default is (1.0, 1.0, 1.0).
-    origin : tuple of int, optional
-        Origin for the OME-NGFF metadata. Default is (0, 0, 0, 0, 0).
-    overwrite : bool, optional
-        Whether to overwrite existing data. Default is False.
-    reducer : Callable, optional
-        Function to use for downsampling. Should accept (array, ...) and
-        return downsampled array. Default is windowed_rank.
-    aws_region : str, optional
-        AWS region name for S3 access. Default is 'us-west-2'.
-    s3_use_ssl : bool, optional
-        Whether to use SSL for S3 access. Default is False.
-    write_empty_chunks : bool, optional
-        Whether to write empty chunks to the store. Default is True.
+        Local path or ``s3://`` URI of the output OME-Zarr group.
+    n_levels : int
+        Requested number of pyramid levels (clamped to what the shape supports).
+    voxel_size : tuple of float
+        Physical voxel size (ZYX) written as the level-0 scale transform.
+    origin : tuple of float
+        Translation transform (TCZYX, or ZYX which is front-padded with zeros).
+    overwrite : bool
+        Overwrite an existing group; when False an existing group is left intact
+        (the tile is skipped).
+    zarr_format : int
+        Output Zarr format, 2 or 3.
+    io_backend : str or ArrayIOBackend
+        ``"tensorstore"`` (default) or ``"zarr"``. Both honor
+        ``write_empty_chunks``.
+    reducer : Callable
+        Downsampling reducer (e.g. ``partial(windowed_rank, rank=-2)`` for image
+        data, ``windowed_mode`` for label/mask data).
+    write_empty_chunks : bool
+        When False, chunks equal to the fill value are not written (sparse output).
     scale_factors : tuple of int, optional
-        Per-axis scale factors used when generating the image pyramid.
-        Defaults to (1, 1, 2, 2, 2).
-    block_shape : tuple of int, optional
-        Chunk shape to use when storing the arrays (TCZYX order).
-        Defaults to (1, 1, 4096, 4096, 4096).
-    codec : numcodecs.abc.Codec, optional
-        Compressor to use when writing the arrays. Defaults to
-        blosc.Blosc(cname="zstd", clevel=1, shuffle=blosc.SHUFFLE).
-    s3_batch_size : int, optional
-        Batch size for S3 multipart uploads. Default is 64.
-    s3_multipart_threshold : int, optional
-        Size threshold in bytes that triggers multipart uploads.
-        Default is 256 * 1024 * 1024 (256 MB).
-    s3_total_max_attempts : int, optional
-        Maximum number of retry attempts for S3 operations. Default is 10.
-    s3_retry_mode : str, optional
-        Retry mode passed to the S3 client. Default is "adaptive".
-
-    Returns
-    -------
-    None
-
-    Raises
-    ------
-    ValueError
-        If the provided scale_factors has fewer than three elements or the
-        block_shape does not describe all five TCZYX axes.
+        Per-axis (TCZYX) downsampling factors. Defaults to (1, 1, 2, 2, 2). A
+        3-tuple (ZYX) is front-padded with (1, 1).
+    chunks : tuple of int, optional
+        Level-0 chunk shape (TCZYX). Defaults to the source array's own chunking
+        (``data.chunksize``).
+    output_shards : "inherit" | "none" | tuple
+        Shard layout for written levels (Zarr v3 only); "none" disables sharding.
+    codec : optional
+        Compressor. Defaults to zstd Blosc appropriate to ``zarr_format``.
     """
-    mode = "w" if overwrite else "w-"
-    try:
-        root_group = initialize_zarr_group(
-            output_zarr,
-            mode=mode,
-            aws_region=aws_region,
-            s3_use_ssl=s3_use_ssl,
-            s3_batch_size=s3_batch_size,
-            s3_multipart_threshold=s3_multipart_threshold,
-            s3_total_max_attempts=s3_total_max_attempts,
-            s3_retry_mode=s3_retry_mode,
-        )
-    except ContainsGroupError:
-        _LOGGER.info(f"Not overwriting tile {output_zarr}")
-        return
-
-    if codec is None:
-        codec = blosc.Blosc(cname="zstd", clevel=1, shuffle=blosc.SHUFFLE)
+    if zarr_format not in (2, 3):
+        raise ValueError(f"Unsupported Zarr format: {zarr_format}")
 
     if scale_factors is None:
-        scale_factors = (1, 1, 2, 2, 2)
+        scale_factors = DEFAULT_SCALE_FACTORS
+    if len(scale_factors) == 3:
+        scale_factors = (1, 1, *scale_factors)
+    if len(scale_factors) != 5:
+        raise ValueError("scale_factors must describe all five TCZYX axes")
 
-    if block_shape is None:
-        block_shape = (1, 1, 4096, 4096, 4096)
+    # Expand to 5D TCZYX.
+    while data.ndim < 5:
+        data = data[np.newaxis, ...]
 
-    if len(scale_factors) < 3:
-        raise ValueError("scale_factors must contain at least three elements")
+    # Default the chunk shape to the source array's own chunking (TCZYX). Inheriting
+    # the input chunks keeps the output layout aligned with the tile being written.
+    if chunks is None:
+        chunks = data.chunksize
+    if len(chunks) != 5:
+        raise ValueError("chunks must be a tuple of length 5")
 
-    if len(block_shape) != 5:
-        raise ValueError("block_shape must be a tuple of length 5")
-
-    while corrected.ndim < 5:
-        corrected = corrected[np.newaxis, ...]
-
-    _LOGGER.info("storing array")
-    store_array(
-        corrected,
-        root_group,
-        "0",
-        block_shape,
-        codec,
-        write_empty_chunks=write_empty_chunks,
+    # Clamp the chunk shape to the array shape so a single chunk never exceeds
+    # the data; otherwise small volumes try to allocate a full oversized chunk.
+    chunks = tuple(
+        max(1, min(int(c), int(s))) for c, s in zip(chunks, data.shape)
     )
-    _LOGGER.info("downsampling array")
-    if reducer == windowed_rank:
-        reducer = partial(reducer, rank=-2)
-    downsample_and_store(
-        corrected,
-        root_group,
-        n_levels,
-        scale_factors,
-        block_shape,
-        codec,
-        reducer,
-        write_empty_chunks=write_empty_chunks,
+
+    backend = io_backend_from_name(io_backend, io_concurrency)
+
+    if codec is None:
+        codec = _default_codec(zarr_format)
+
+    target = _open_output_group(
+        output_zarr,
+        overwrite=overwrite,
+        zarr_format=zarr_format,
+        aws_region=aws_region,
+        s3_use_ssl=s3_use_ssl,
+        s3_total_max_attempts=s3_total_max_attempts,
+        s3_retry_mode=s3_retry_mode,
     )
-    _LOGGER.info("writing ome metadata")
+    if target is None:
+        _LOGGER.info("Not overwriting existing tile %s", output_zarr)
+        return
+
+    # Level-0 spec (format-aware codec/shards).
+    level0_shards = output_shards if (zarr_format == 3 and isinstance(output_shards, tuple)) else None
+    spec_kwargs: dict[str, Any] = {
+        "zarr_format": zarr_format,
+        "chunks": tuple(chunks),
+        "write_empty_chunks": write_empty_chunks,
+        # An explicit (non-null) fill value is required for the tensorstore
+        # backend to elide all-fill-value chunks when write_empty_chunks=False;
+        # a null v2 fill value leaves nothing to compare against. 0 is the
+        # background value for these volumes and matches the v3 default.
+        "fill_value": 0,
+    }
+    if zarr_format == 2:
+        spec_kwargs["compressor"] = codec
+    else:
+        spec_kwargs["compressors"] = (codec,)
+        spec_kwargs["shards"] = level0_shards
+        spec_kwargs["dimension_names"] = ("t", "c", "z", "y", "x")
+    spec0 = ArraySpec.from_dask(data, **spec_kwargs)
+
+    _LOGGER.info("Writing level 0 to %s (zarr v%d, %s)", output_zarr, zarr_format, backend.name)
+    write_dask_array(data, target, "0", spec=spec0, io_backend=backend, overwrite=True)
+
+    # Generate pyramid levels 1..levels-1 (clamped to what the shape supports).
+    levels = _max_levels(data, scale_factors, reducer, n_levels)
+    if levels < n_levels:
+        _LOGGER.warning(
+            "Requested %d levels but shape %s only supports %d; clamping.",
+            n_levels,
+            tuple(int(s) for s in data.shape),
+            levels,
+        )
+    if levels > 1:
+        _LOGGER.info("Generating %d pyramid levels", levels - 1)
+        write_multiscale_pyramid(
+            target,
+            target,
+            io_backend=backend,
+            n_levels=levels,
+            scale_factors=scale_factors,
+            output_shards=output_shards,
+            reducer=reducer,
+            ome_metadata=False,
+            include_level_zero=True,
+            write_empty_chunks=write_empty_chunks,
+        )
+
+    # Write OME-NGFF metadata, preserving voxel_size/origin from the input tile.
+    base_scale = _to_5d_vector(voxel_size, fill=1.0)
+    base_translation = _to_5d_vector(origin, fill=0.0)
+    _LOGGER.info("Writing OME-NGFF metadata for %s", output_zarr)
     write_ome_ngff_metadata(
-        root_group,
-        corrected,
-        Path(output_zarr).stem,
-        n_levels,
-        scale_factors[-3:],  # must be 3D
-        voxel_size,  # must be 3D ZYX
-        origin,
+        target.group,
+        source_attrs={},
+        source_path=output_zarr,
+        level_paths=[str(i) for i in range(levels)],
+        base_scale=base_scale,
+        base_translation=base_translation,
+        scale_factors=scale_factors,
+        axes=axes_from_attrs({}, ndim=5),
+        downsample_type=reducer_name(reducer),
     )
 
 
-def parse_ome_zarr_transformations(z: zarr.hierarchy.Group, res: str) -> dict:
-    """
-    Parse scale and translation transformations for a given resolution in
-    an OME-Zarr dataset.
-
-    Parameters
-    ----------
-    z : zarr.hierarchy.Group
-        Opened zarr group for the dataset.
-    res : str
-        Resolution key to extract transformations for.
-
-    Returns
-    -------
-    dict
-        Dictionary containing 'scale' and 'translation' for the
-        specified resolution.
-
-    Raises
-    ------
-    ValueError
-        If OME-Zarr metadata is not found.
-    """
-
-    # Read the metadata from .zattrs
+def _open_output_group(
+    output_zarr: str,
+    *,
+    overwrite: bool,
+    zarr_format: int,
+    **s3_kwargs: Any,
+) -> ArrayTarget | None:
+    """Open the output group, returning None if it exists and overwrite is False."""
+    mode = "w" if overwrite else "w-"
     try:
-        metadata = z.attrs.asdict()
-    except KeyError:
-        raise ValueError("OME-Zarr metadata not found.")
+        group = open_group(output_zarr, mode=mode, zarr_format=zarr_format, **s3_kwargs)
+    except (FileExistsError, ContainsGroupError):
+        return None
+    return ArrayTarget.from_group(group, path=output_zarr)
 
-    res = str(res)
 
-    # Extract transformations for the first dataset
-    transformations = {}
-    multiscales = metadata.get("multiscales", [])
+def _default_codec(zarr_format: int) -> Any:
+    """Return a zstd Blosc compressor appropriate to the Zarr format."""
+    if zarr_format == 2:
+        from numcodecs import blosc
 
-    if multiscales:
-        datasets = multiscales[0].get("datasets", [])
-        for ds in datasets:
-            if ds["path"] == res:
-                coord_transforms = ds.get("coordinateTransformations", [])
-                scale = next(
-                    (
-                        t["scale"]
-                        for t in coord_transforms
-                        if t["type"] == "scale"
-                    ),
-                    None,
-                )
-                translation = next(
-                    (
-                        t["translation"]
-                        for t in coord_transforms
-                        if t["type"] == "translation"
-                    ),
-                    None,
-                )
-                transformations = {"scale": scale, "translation": translation}
-                break
+        return blosc.Blosc(cname="zstd", clevel=1, shuffle=blosc.SHUFFLE)
+    from zarr.codecs import BloscCodec, BloscShuffle
 
-    return transformations
+    return BloscCodec(cname="zstd", clevel=1, shuffle=BloscShuffle.shuffle)
+
+
+def _to_5d_vector(values: tuple[float, ...] | list[float], *, fill: float) -> list[float]:
+    """Coerce a transform vector to length 5 (TCZYX), front-padding with ``fill``."""
+    vec = [float(v) for v in values]
+    if len(vec) >= 5:
+        return vec[:5]
+    return [fill] * (5 - len(vec)) + vec
+
+
+def _max_levels(
+    data: da.Array,
+    scale_factors: tuple[int, ...],
+    reducer: Callable[..., Any],
+    requested: int,
+) -> int:
+    """Number of pyramid levels (incl. level 0) the data supports, capped at ``requested``.
+
+    Uses xarray-multiscale to count levels so the result matches exactly what
+    ``write_multiscale_pyramid`` validates against (a heuristic can over-count and
+    trigger a ValueError downstream). The lazy pyramid built here is discarded.
+    """
+    levels = _xarray_multiscale(data, reducer, scale_factors)
+    return min(requested, len(levels))
 
 
 def get_zarr_tiles(
-    z, res: int = 5, chunks: tuple[int, ...] = None
+    z: zarr.Group, res: int = 5, chunks: tuple[int, ...] = None
 ) -> list[da.Array]:
-    """
-    Extract tiles from a zarr group at a given resolution as Dask arrays.
+    """Extract tiles from a zarr group at a given resolution as Dask arrays.
 
     Parameters
     ----------
-    z : zarr.hierarchy.Group
+    z : zarr.Group
         Zarr group containing tiles.
     res : int, optional
         Resolution level to extract. Default is 5.

--- a/code/exaspim_flatfield_correction/utils/zarr_utils.py
+++ b/code/exaspim_flatfield_correction/utils/zarr_utils.py
@@ -137,13 +137,20 @@ def store_ome_zarr(
     chunks : tuple of int, optional
         Level-0 chunk shape (TCZYX). Defaults to the source array's own chunking
         (``data.chunksize``).
-    output_shards : "inherit" | "none" | tuple
-        Shard layout for written levels (Zarr v3 only); "none" disables sharding.
+    output_shards : "inherit" | "none" | None | tuple
+        Shard layout for written levels (Zarr v3 only); "none" (or None)
+        disables sharding.
     codec : optional
         Compressor. Defaults to zstd Blosc appropriate to ``zarr_format``.
     """
     if zarr_format not in (2, 3):
         raise ValueError(f"Unsupported Zarr format: {zarr_format}")
+
+    # Accept None as an alias for "none": zarr_io's parse_output_shards only
+    # understands the string sentinels ("inherit"/"none") or a shard tuple, and
+    # chokes on None inside write_multiscale_pyramid.
+    if output_shards is None:
+        output_shards = "none"
 
     if scale_factors is None:
         scale_factors = DEFAULT_SCALE_FACTORS

--- a/code/exaspim_flatfield_correction/utils/zarr_utils.py
+++ b/code/exaspim_flatfield_correction/utils/zarr_utils.py
@@ -85,6 +85,7 @@ def store_ome_zarr(
     io_concurrency: IOConcurrencyConfig | None = None,
     reducer: Callable[..., Any] = DEFAULT_REDUCER,
     write_empty_chunks: bool = True,
+    max_chunks_per_block: int | None = 16384,
     scale_factors: tuple[int, ...] | None = None,
     chunks: tuple[int, ...] | None = None,
     output_shards: OutputShards = "none",
@@ -125,6 +126,11 @@ def store_ome_zarr(
         data, ``windowed_mode`` for label/mask data).
     write_empty_chunks : bool
         When False, chunks equal to the fill value are not written (sparse output).
+    max_chunks_per_block : int or None
+        Maximum chunks per ``dask.compute`` for the level-0 write. Large arrays
+        are written in chunk-aligned slabs of at most this many chunks so the
+        scheduler isn't overwhelmed by one giant graph. ``None`` writes in a
+        single compute (zarr_io's legacy behavior).
     scale_factors : tuple of int, optional
         Per-axis (TCZYX) downsampling factors. Defaults to (1, 1, 2, 2, 2). A
         3-tuple (ZYX) is front-padded with (1, 1).
@@ -207,7 +213,18 @@ def store_ome_zarr(
     spec0 = ArraySpec.from_dask(data, **spec_kwargs)
 
     _LOGGER.info("Writing level 0 to %s (zarr v%d, %s)", output_zarr, zarr_format, backend.name)
-    write_dask_array(data, target, "0", spec=spec0, io_backend=backend, overwrite=True)
+    # Slab the (potentially massive) level-0 write so the scheduler isn't handed a
+    # single million-task graph. Pyramid levels are downsampled and far smaller;
+    # write_multiscale_pyramid relies on zarr_io's own default budget for those.
+    write_dask_array(
+        data,
+        target,
+        "0",
+        spec=spec0,
+        io_backend=backend,
+        overwrite=True,
+        max_chunks_per_block=max_chunks_per_block,
+    )
 
     # Generate pyramid levels 1..levels-1 (clamped to what the shape supports).
     levels = _max_levels(data, scale_factors, reducer, n_levels)
@@ -231,6 +248,7 @@ def store_ome_zarr(
             ome_metadata=False,
             include_level_zero=True,
             write_empty_chunks=write_empty_chunks,
+            max_chunks_per_block=max_chunks_per_block,
         )
 
     # Write OME-NGFF metadata, preserving voxel_size/origin from the input tile.

--- a/code/exaspim_flatfield_correction/utils/zarr_utils.py
+++ b/code/exaspim_flatfield_correction/utils/zarr_utils.py
@@ -12,6 +12,7 @@ from typing import Any, Callable
 import dask.array as da
 import numpy as np
 import zarr
+from zarr.errors import ContainsGroupError
 
 from xarray_multiscale import multiscale as _xarray_multiscale
 from xarray_multiscale.reducers import windowed_rank

--- a/code/run
+++ b/code/run
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-source $(conda info --base)/etc/profile.d/conda.sh
-conda activate correction
-
 export AWS_REQUEST_CHECKSUM_CALCULATION=when_required
 export AWS_RESPONSE_CHECKSUM_VALIDATION=when_required
 

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,6 +1,6 @@
-# hash:sha256:5a44117304dbda73bb7fa33cd49aea6723cae3f4617440f8cd6e335ef7c84f19
+# hash:sha256:2e712d5589862e3bf09258d13934ac60a79a193978420538b6f3ce5fa95ea0e1
 ARG REGISTRY_HOST
-FROM $REGISTRY_HOST/codeocean/mambaforge3:23.1.0-4-python3.10.12-ubuntu22.04
+FROM $REGISTRY_HOST/codeocean/mambaforge3:24.5.0-0-python3.12.4-ubuntu22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG GIT_ASKPASS
@@ -8,18 +8,18 @@ COPY git-ask-pass /
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        build-essential=12.9ubuntu3 \
-        ninja-build=1.10.1-1 \
-        wget=1.21.2-2ubuntu1.1 \
-        zip=3.0-12build2 \
+        build-essential \
+        ninja-build \
+        wget \
+        zip \
     && rm -rf /var/lib/apt/lists/*
 
-ADD "https://github.com/coder/code-server/releases/download/v4.100.3/code-server-4.100.3-linux-amd64.tar.gz" /.code-server/code-server.tar.gz
+ADD "https://github.com/coder/code-server/releases/download/v4.123.0/code-server-4.123.0-linux-amd64.tar.gz" /.code-server/code-server.tar.gz
 
 RUN cd /.code-server \
     && tar -xvf code-server.tar.gz \
     && rm code-server.tar.gz \
-    && ln -s /.code-server/code-server-4.100.3-linux-amd64/bin/code-server /usr/bin/code-server \
+    && ln -s /.code-server/code-server-4.123.0-linux-amd64/bin/code-server /usr/bin/code-server \
     && mkdir -p /.vscode/extensions
 
 COPY postInstall /

--- a/environment/environment.yml
+++ b/environment/environment.yml
@@ -1,8 +1,0 @@
-environment_version: 1
-credentials:
-- type: aws
-  id: NWcvEWzm9p0BMJ
-  description: cameronaws
-  access_key_id: AWS_ACCESS_KEY_ID
-  secret_access_key: AWS_SECRET_ACCESS_KEY
-  region: AWS_DEFAULT_REGION

--- a/environment/postInstall
+++ b/environment/postInstall
@@ -2,7 +2,7 @@
 set -euo pipefail
 git clone https://github.com/AllenNeuralDynamics/exaspim-flatfield-correction.git
 cd exaspim-flatfield-correction
-git checkout feat-zarr3
+git checkout b0bc597dd34135a969777d164f81f73cdaa12f41
 pip install .
 
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"

--- a/environment/postInstall
+++ b/environment/postInstall
@@ -1,18 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
-conda update conda -y
-conda update mamba -y
-mamba create -n correction -c conda-forge python=3.11 -y
-source $(conda info --base)/etc/profile.d/conda.sh
-conda activate correction
-
 git clone https://github.com/AllenNeuralDynamics/exaspim-flatfield-correction.git
 cd exaspim-flatfield-correction
-git checkout 8427ec6ec9c2976e6f4726ae929ec05643a608d2
+git checkout feat-zarr3
 pip install .
-
-pip install "aind-data-schema==2.6.0"
 
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip awscliv2.zip

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,25 +12,31 @@ package_dir =
 install_requires =
     pytest==9.0.3
     numpy>=2.1.0
-    zarr==2.18.7
+    zarr==3.2.1
     numcodecs
     tifffile
-    dask==2024.11.2
-    distributed==2024.11.2
-    bokeh==3.3.0
+    aind-data-schema==2.6.0
+    dask==2026.6.0
+    distributed==2026.6.0
+    bokeh>=3.3.0
     scipy==1.15.2
     dask-image
+    scikit-image
     scikit-learn
     pydantic>=2.6
     hdf5plugin
-    kerchunk==0.2.6
-    s3fs==2025.7.0
-    boto3[crt]==1.37.2
+    s3fs==2025.12.0
+    tensorstore==0.1.84
+    fsspec
+    xarray
+    xarray-multiscale==1.2.0
+    boto3[crt]==1.41.5
     ujson
     matplotlib
-    aind-data-transfer[imaging] @ git+https://github.com/AllenNeuralDynamics/aind-data-transfer.git@feat-skip-empty-chunks
+    zarr-io @ git+https://github.com/AllenNeuralDynamics/zarr-io.git@main
+    zarr-multiscale @ git+https://github.com/AllenNeuralDynamics/zarr-multiscale.git@main
 
-python_requires = >=3.11
+python_requires = >=3.12
 include_package_data = True
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     aind-data-schema==2.6.0
     dask==2024.11.2
     distributed==2024.11.2
-    bokeh>=3.3.0
+    bokeh>=3.3.0,<3.9
     scipy==1.15.2
     dask-image
     scikit-image

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,8 @@ install_requires =
     numcodecs
     tifffile
     aind-data-schema==2.6.0
-    dask==2026.6.0
-    distributed==2026.6.0
+    dask==2024.11.2
+    distributed==2024.11.2
     bokeh>=3.3.0
     scipy==1.15.2
     dask-image

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -29,8 +29,8 @@ def _transform(z_scale: float, z_translation: float = 0.0) -> dict:
     }
 
 
-def _write_multiscale_metadata(root: zarr.Group) -> None:
-    root.attrs["multiscales"] = [
+def _multiscale_block() -> list[dict]:
+    return [
         {
             "datasets": [
                 {
@@ -56,6 +56,29 @@ def _write_multiscale_metadata(root: zarr.Group) -> None:
             ]
         }
     ]
+
+
+def _write_multiscale_metadata(root: zarr.Group, zarr_format: int = 2) -> None:
+    """Write OME-NGFF multiscales in the layout matching the Zarr format.
+
+    Zarr v3 -> OME-NGFF 0.5 (nested under ``ome``); Zarr v2 -> 0.4 (top level).
+    """
+    block = _multiscale_block()
+    if zarr_format == 3:
+        root.attrs["ome"] = {"version": "0.5", "multiscales": block}
+    else:
+        root.attrs["multiscales"] = block
+
+
+def _create_array(
+    root: zarr.Group, name: str, data: np.ndarray, chunks: tuple[int, ...]
+) -> zarr.Array:
+    """Create a Zarr array (v2 or v3, per the group) and fill it with ``data``."""
+    arr = root.create_array(
+        name, shape=data.shape, dtype=data.dtype, chunks=chunks
+    )
+    arr[:] = data
+    return arr
 
 
 def _graph_contains_text(arr: da.Array, text: str) -> bool:
@@ -118,9 +141,12 @@ def test_estimate_bkg_from_mapped_slices_uses_target_planes() -> None:
     np.testing.assert_array_equal(bkg, np.median(data[[2, 3]], axis=0))
 
 
-def test_background_subtraction_uses_cached_background_zarr(tmp_path) -> None:
+@pytest.mark.parametrize("zarr_format", [2, 3])
+def test_background_subtraction_uses_cached_background_zarr(
+    tmp_path, zarr_format
+) -> None:
     store = zarr.storage.MemoryStore()
-    root = zarr.group(store=store)
+    root = zarr.group(store=store, zarr_format=zarr_format)
 
     full_res_data = np.asarray(
         [
@@ -138,11 +164,13 @@ def test_background_subtraction_uses_cached_background_zarr(tmp_path) -> None:
         dtype=np.float32,
     )
 
-    root.create_dataset("0", data=full_res_data, chunks=(1, 2, 2))
-    root.create_dataset("3", data=low_res_data, chunks=(1, 2, 2))
-    _write_multiscale_metadata(root)
+    _create_array(root, "0", full_res_data, (1, 2, 2))
+    _create_array(root, "3", low_res_data, (1, 2, 2))
+    _write_multiscale_metadata(root, zarr_format)
 
     full_res = da.from_zarr(root["0"]).astype(np.float32)
+    # MemoryStore is only reachable via the zarr backend (TensorStore opens by
+    # URI/kvstore, not an in-memory zarr-python store).
     corrected, bkg, bkg_slice_indices, cache_path = background_subtraction(
         "synthetic_tile.zarr",
         full_res,
@@ -153,6 +181,7 @@ def test_background_subtraction_uses_cached_background_zarr(tmp_path) -> None:
         background_smoothing_sigma=0,
         background_final_smoothing_sigma=0,
         target_resolution="0",
+        io_backend="zarr",
     )
 
     expected_bkg = np.full((2, 2), 40, dtype=np.float32)
@@ -170,12 +199,14 @@ def test_background_subtraction_uses_cached_background_zarr(tmp_path) -> None:
     assert not cache_path.exists()
 
 
+@pytest.mark.parametrize("zarr_format", [2, 3])
 def test_background_subtraction_blurs_final_cached_background_with_dask(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
+    zarr_format,
 ) -> None:
     store = zarr.storage.MemoryStore()
-    root = zarr.group(store=store)
+    root = zarr.group(store=store, zarr_format=zarr_format)
 
     raw_bkg = np.zeros((11, 11), dtype=np.float32)
     raw_bkg[5, 5] = 90
@@ -194,9 +225,9 @@ def test_background_subtraction_blurs_final_cached_background_with_dask(
         dtype=np.float32,
     )
 
-    root.create_dataset("0", data=full_res_data, chunks=(1, 11, 11))
-    root.create_dataset("3", data=low_res_data, chunks=(1, 11, 11))
-    _write_multiscale_metadata(root)
+    _create_array(root, "0", full_res_data, (1, 11, 11))
+    _create_array(root, "3", low_res_data, (1, 11, 11))
+    _write_multiscale_metadata(root, zarr_format)
 
     calls = []
     original_gaussian_filter = pipeline_module.gaussian_filter_dask
@@ -222,6 +253,7 @@ def test_background_subtraction_blurs_final_cached_background_with_dask(
         background_smoothing_sigma=0,
         background_final_smoothing_sigma=1,
         target_resolution="0",
+        io_backend="zarr",
     )
 
     expected_bkg = gaussian_filter_np(raw_bkg, sigma=1).astype(np.float32)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 from exaspim_flatfield_correction.config import (
+    IOConcurrencyConfig,
     PipelineConfig,
     load_pipeline_config,
 )
@@ -156,3 +157,60 @@ def test_pipeline_config_rejects_invalid_zarr_v3_fields(field, value) -> None:
 
     with pytest.raises(ValueError, match=field):
         PipelineConfig.model_validate(payload)
+
+
+def test_io_concurrency_defaults_to_four_on_every_knob() -> None:
+    config = PipelineConfig.model_validate(_sample_pipeline_config())
+
+    io = config.io_concurrency
+    assert io.zarr_async_concurrency == 4
+    assert io.zarr_threading_max_workers == 4
+    assert io.tensorstore_data_copy_concurrency == 4
+    assert io.tensorstore_file_io_concurrency == 4
+    assert io.tensorstore_s3_request_concurrency == 4
+    assert io.tensorstore_http_request_concurrency == 4
+
+
+def test_io_concurrency_converts_to_zarr_io_dataclass() -> None:
+    converted = IOConcurrencyConfig().to_io_concurrency()
+
+    # All six knobs populated -> both backend spec builders are fully configured.
+    assert converted.zarr_config() == {
+        "async.concurrency": 4,
+        "threading.max_workers": 4,
+    }
+    assert converted.tensorstore_context_spec() == {
+        "data_copy_concurrency": {"limit": 4},
+        "file_io_concurrency": {"limit": 4},
+        "s3_request_concurrency": {"limit": 4},
+        "http_request_concurrency": {"limit": 4},
+    }
+
+
+def test_io_concurrency_accepts_overrides_and_null() -> None:
+    payload = _sample_pipeline_config()
+    payload["io_concurrency"] = {
+        "tensorstore_s3_request_concurrency": 32,
+        "zarr_async_concurrency": None,
+    }
+
+    config = PipelineConfig.model_validate(payload)
+
+    assert config.io_concurrency.tensorstore_s3_request_concurrency == 32
+    # null -> fall back to the backend library default for that single limit.
+    assert config.io_concurrency.zarr_async_concurrency is None
+    assert config.io_concurrency.to_io_concurrency().zarr_config() == {
+        "threading.max_workers": 4,
+    }
+
+
+def test_io_concurrency_rejects_unknown_and_nonpositive_knobs() -> None:
+    bad_key = _sample_pipeline_config()
+    bad_key["io_concurrency"] = {"bogus_knob": 4}
+    with pytest.raises(ValueError, match="bogus_knob"):
+        PipelineConfig.model_validate(bad_key)
+
+    bad_value = _sample_pipeline_config()
+    bad_value["io_concurrency"] = {"tensorstore_file_io_concurrency": 0}
+    with pytest.raises(ValueError, match="tensorstore_file_io_concurrency"):
+        PipelineConfig.model_validate(bad_value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,3 +120,39 @@ def test_pipeline_config_infers_binned_channel_when_marked_binned() -> None:
     config = PipelineConfig.model_validate(payload)
 
     assert config.binned_channel == "488"
+
+
+def test_pipeline_config_defaults_for_zarr_v3_fields() -> None:
+    config = PipelineConfig.model_validate(_sample_pipeline_config())
+
+    assert config.io_backend == "tensorstore"
+    assert config.output_zarr_format == "match"
+    assert config.corrected_rank == -2
+
+
+def test_pipeline_config_accepts_zarr_v3_field_overrides() -> None:
+    payload = _sample_pipeline_config()
+    payload["io_backend"] = "zarr"
+    payload["output_zarr_format"] = "3"
+    payload["corrected_rank"] = 0
+
+    config = PipelineConfig.model_validate(payload)
+
+    assert config.io_backend == "zarr"
+    assert config.output_zarr_format == "3"
+    assert config.corrected_rank == 0
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("io_backend", "numpy"),
+        ("output_zarr_format", "5"),
+    ],
+)
+def test_pipeline_config_rejects_invalid_zarr_v3_fields(field, value) -> None:
+    payload = _sample_pipeline_config()
+    payload[field] = value
+
+    with pytest.raises(ValueError, match=field):
+        PipelineConfig.model_validate(payload)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -163,12 +163,12 @@ def test_io_concurrency_defaults_to_four_on_every_knob() -> None:
     config = PipelineConfig.model_validate(_sample_pipeline_config())
 
     io = config.io_concurrency
-    assert io.zarr_async_concurrency == 4
-    assert io.zarr_threading_max_workers == 4
-    assert io.tensorstore_data_copy_concurrency == 4
-    assert io.tensorstore_file_io_concurrency == 4
-    assert io.tensorstore_s3_request_concurrency == 4
-    assert io.tensorstore_http_request_concurrency == 4
+    assert io.zarr_async_concurrency == 8
+    assert io.zarr_threading_max_workers == 8
+    assert io.tensorstore_data_copy_concurrency == 8
+    assert io.tensorstore_file_io_concurrency == 8
+    assert io.tensorstore_s3_request_concurrency == 8
+    assert io.tensorstore_http_request_concurrency == 8
 
 
 def test_io_concurrency_converts_to_zarr_io_dataclass() -> None:
@@ -176,14 +176,14 @@ def test_io_concurrency_converts_to_zarr_io_dataclass() -> None:
 
     # All six knobs populated -> both backend spec builders are fully configured.
     assert converted.zarr_config() == {
-        "async.concurrency": 4,
-        "threading.max_workers": 4,
+        "async.concurrency": 8,
+        "threading.max_workers": 8,
     }
     assert converted.tensorstore_context_spec() == {
-        "data_copy_concurrency": {"limit": 4},
-        "file_io_concurrency": {"limit": 4},
-        "s3_request_concurrency": {"limit": 4},
-        "http_request_concurrency": {"limit": 4},
+        "data_copy_concurrency": {"limit": 8},
+        "file_io_concurrency": {"limit": 8},
+        "s3_request_concurrency": {"limit": 8},
+        "http_request_concurrency": {"limit": 8},
     }
 
 
@@ -200,7 +200,7 @@ def test_io_concurrency_accepts_overrides_and_null() -> None:
     # null -> fall back to the backend library default for that single limit.
     assert config.io_concurrency.zarr_async_concurrency is None
     assert config.io_concurrency.to_io_concurrency().zarr_config() == {
-        "threading.max_workers": 4,
+        "threading.max_workers": 8,
     }
 
 

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -1,0 +1,54 @@
+"""Tests for fitting helpers (probability-weight computation, etc.)."""
+
+from __future__ import annotations
+
+import dask.array as da
+import numpy as np
+import pytest
+
+from exaspim_flatfield_correction.fitting import calc_percentile_weight
+
+
+@pytest.mark.parametrize("smooth_sigma", [0.0, 3.0])
+def test_calc_percentile_weight_is_float32(smooth_sigma) -> None:
+    """The returned weights must actually compute as float32, not just declare it.
+
+    Regression test: under NEP 50 (NumPy 2.x) the ``np.float64`` scalar ``B`` in
+    the Richards block promoted the float32 block to float64, so the dask array
+    *declared* float32 while *computing* float64. The trailing ``.astype`` was a
+    silent no-op (meta already float32), and the float64 chunks failed the
+    ``safe`` cast into a float32 zarr store. Guard both the declared and the
+    actually-computed dtype.
+    """
+    rng = np.random.default_rng(0)
+    img = da.from_array(
+        (rng.random((32, 128, 128)) * 1000).astype(np.float32),
+        chunks=(16, 128, 128),
+    )
+    bg = (rng.random((8, 128, 128)) * 1000).astype(np.float32)
+
+    weights = calc_percentile_weight(
+        img,
+        bg,
+        low_percentile=50.0,
+        high_percentile=99.9,
+        eps=0.001,
+        smooth_sigma=smooth_sigma,
+    )
+    computed = weights.compute()
+
+    assert weights.dtype == np.float32
+    assert computed.dtype == np.float32
+    assert computed.min() >= 0.0
+    assert computed.max() <= 1.0
+
+
+def test_calc_percentile_weight_degenerate_is_float32() -> None:
+    """The degenerate (zero-width) percentile branch also stays float32."""
+    img = da.from_array(np.full((32, 128, 128), 5.0, np.float32), chunks=(16, 128, 128))
+    bg = np.full((8, 128, 128), 5.0, np.float32)
+
+    weights = calc_percentile_weight(img, bg, smooth_sigma=0.0)
+
+    assert weights.dtype == np.float32
+    assert weights.compute().dtype == np.float32

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -1,0 +1,142 @@
+"""Tests for choosing the output Zarr format independently of the input.
+
+Covers ``resolve_output_format`` (the config -> int resolution, including the
+"match" path that reads the input tile's format) and a true cross-format
+read->write round-trip (v3 input -> v2 output and vice versa) through the same
+``zarr-io`` helpers the pipeline uses.
+
+All paths are local ``tmp_path`` and the zarr backend is used throughout, so the
+tests require neither tensorstore nor S3.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import dask.array as da
+
+from exaspim_flatfield_correction.config import PipelineConfig
+from exaspim_flatfield_correction.pipeline import resolve_output_format
+from exaspim_flatfield_correction.utils.zarr_utils import (
+    ensure_group,
+    parse_ome_zarr_transformations,
+    store_ome_zarr,
+)
+from zarr_io.arrays import open_group, read_zarr_array
+
+
+def _make_input_tile(
+    path: str,
+    *,
+    zarr_format: int,
+    raw: np.ndarray,
+    voxel_size: tuple[float, float, float],
+    origin: tuple[float, ...],
+) -> None:
+    """Write a real input OME-Zarr tile (data + metadata) in ``zarr_format``."""
+    data = da.from_array(raw, chunks=raw.shape)
+    store_ome_zarr(
+        data,
+        path,
+        n_levels=1,
+        voxel_size=voxel_size,
+        origin=origin,
+        overwrite=True,
+        zarr_format=zarr_format,
+        io_backend="zarr",
+    )
+
+
+def _pipeline_config(tile_path: str, output_zarr_format: str) -> PipelineConfig:
+    """Minimal valid config for exercising ``resolve_output_format``.
+
+    ``method="basicpy"`` avoids the fitting cross-field requirements
+    (mask_dir / background subtraction).
+    """
+    return PipelineConfig.model_validate(
+        {
+            "method": "basicpy",
+            "tile_paths": [str(tile_path)],
+            "output": "/tmp/flatfield_out.ome.zarr",
+            "output_zarr_format": output_zarr_format,
+        }
+    )
+
+
+@pytest.mark.parametrize("in_fmt", [2, 3])
+def test_resolve_output_format_match_follows_input(tmp_path, in_fmt) -> None:
+    tile_path = str(tmp_path / f"tile_v{in_fmt}.zarr")
+    ensure_group(tile_path, zarr_format=in_fmt, mode="w")
+
+    cfg = _pipeline_config(tile_path, "match")
+
+    assert resolve_output_format(cfg) == in_fmt
+
+
+@pytest.mark.parametrize(
+    "in_fmt, forced",
+    [(3, "2"), (2, "3"), (2, "2"), (3, "3")],
+)
+def test_resolve_output_format_forced_overrides_input(
+    tmp_path, in_fmt, forced
+) -> None:
+    tile_path = str(tmp_path / f"tile_v{in_fmt}.zarr")
+    ensure_group(tile_path, zarr_format=in_fmt, mode="w")
+
+    cfg = _pipeline_config(tile_path, forced)
+
+    # The forced format wins regardless of the input tile's format.
+    assert resolve_output_format(cfg) == int(forced)
+
+
+@pytest.mark.parametrize(
+    "in_fmt, out_fmt",
+    [(3, 2), (2, 3), (2, 2), (3, 3)],
+)
+def test_cross_format_conversion_roundtrip(tmp_path, in_fmt, out_fmt) -> None:
+    """Read a tile written in ``in_fmt`` and rewrite it in ``out_fmt``.
+
+    Exercises the pipeline's actual read->write boundary (open_group +
+    read_zarr_array + parse_ome_zarr_transformations -> store_ome_zarr).
+    """
+    raw = np.arange(8 * 16 * 16, dtype=np.uint16).reshape(8, 16, 16)
+    voxel_size = (2.0, 0.5, 0.5)
+    origin = (0, 0, 10, 20, 30)
+
+    in_path = str(tmp_path / f"in_v{in_fmt}.zarr")
+    out_path = str(tmp_path / f"out_v{out_fmt}.zarr")
+    _make_input_tile(
+        in_path, zarr_format=in_fmt, raw=raw, voxel_size=voxel_size, origin=origin
+    )
+
+    # Read exactly as the pipeline does (format-agnostic).
+    z = open_group(in_path, mode="r")
+    assert int(z.metadata.zarr_format) == in_fmt
+    data = read_zarr_array(z, component="0", io_backend="zarr")
+    transforms = parse_ome_zarr_transformations(z, "0")
+
+    # Write in the (possibly different) output format.
+    store_ome_zarr(
+        data,
+        out_path,
+        n_levels=1,
+        voxel_size=tuple(transforms["scale"][-3:]),
+        origin=transforms["translation"],
+        overwrite=True,
+        zarr_format=out_fmt,
+        io_backend="zarr",
+    )
+
+    out = open_group(out_path, mode="r")
+    assert int(out.metadata.zarr_format) == out_fmt
+
+    out_data = (
+        read_zarr_array(out, component="0", io_backend="zarr").squeeze().compute()
+    )
+    np.testing.assert_array_equal(out_data.astype(np.uint16), raw)
+
+    # Scale/translation survive the cross-format conversion.
+    out_transforms = parse_ome_zarr_transformations(out, "0")
+    assert out_transforms["scale"] == [1.0, 1.0, 2.0, 0.5, 0.5]
+    assert out_transforms["translation"] == [0.0, 0.0, 10.0, 20.0, 30.0]

--- a/tests/test_zarr_utils.py
+++ b/tests/test_zarr_utils.py
@@ -1,0 +1,242 @@
+"""Tests for OME-Zarr writing (v2 + v3) via zarr-io / zarr-multiscale.
+
+These exercise the rewritten ``store_ome_zarr`` and the v0.4/v0.5-aware
+metadata parser. They require the new stack (zarr 3.x, zarr-io, zarr-multiscale,
+xarray-multiscale); the TensorStore cases skip when tensorstore is unavailable.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from pathlib import Path
+
+import dask.array as da
+import numpy as np
+import pytest
+
+from exaspim_flatfield_correction.utils.zarr_utils import (
+    parse_ome_zarr_transformations,
+    store_ome_zarr,
+)
+from zarr_io.arrays import open_group, read_zarr_array
+
+BACKENDS = ["zarr", "tensorstore"]
+
+
+def _maybe_skip_backend(io_backend: str) -> None:
+    if io_backend == "tensorstore":
+        pytest.importorskip("tensorstore")
+
+
+def _multiscales(group, zarr_format: int) -> dict:
+    attrs = dict(group.attrs)
+    if zarr_format == 3:
+        return attrs["ome"]["multiscales"][0]
+    return attrs["multiscales"][0]
+
+
+@pytest.mark.parametrize("zarr_format", [2, 3])
+@pytest.mark.parametrize("io_backend", BACKENDS)
+def test_store_ome_zarr_roundtrip(tmp_path, zarr_format, io_backend) -> None:
+    _maybe_skip_backend(io_backend)
+    raw = np.arange(8 * 16 * 16, dtype=np.uint16).reshape(8, 16, 16)
+    data = da.from_array(raw, chunks=(8, 16, 16))
+    out = str(tmp_path / f"tile_v{zarr_format}_{io_backend}.zarr")
+
+    store_ome_zarr(
+        data,
+        out,
+        n_levels=3,
+        voxel_size=(2.0, 0.5, 0.5),
+        origin=(0, 0, 10, 20, 30),
+        overwrite=True,
+        zarr_format=zarr_format,
+        io_backend=io_backend,
+        chunks=(1, 1, 4, 8, 8),
+    )
+
+    group = open_group(out, mode="r")
+    assert int(group.metadata.zarr_format) == zarr_format
+    for level in ("0", "1", "2"):
+        assert level in group
+
+    level0 = read_zarr_array(group, component="0", io_backend="zarr")
+    assert tuple(int(s) for s in level0.shape) == (1, 1, 8, 16, 16)
+    np.testing.assert_array_equal(level0.squeeze().compute().astype(np.uint16), raw)
+
+    # Level-0 scale == [1, 1, *voxel_size]; translation preserved; level-1 doubled.
+    t0 = parse_ome_zarr_transformations(group, "0")
+    assert t0["scale"] == [1.0, 1.0, 2.0, 0.5, 0.5]
+    assert t0["translation"] == [0.0, 0.0, 10.0, 20.0, 30.0]
+    t1 = parse_ome_zarr_transformations(group, "1")
+    assert t1["scale"] == [1.0, 1.0, 4.0, 1.0, 1.0]
+
+
+@pytest.mark.parametrize("zarr_format", [2, 3])
+def test_store_ome_zarr_inherits_source_chunks(tmp_path, zarr_format) -> None:
+    """When ``chunks`` is omitted, the level-0 chunk shape inherits ``data.chunksize``."""
+    raw = np.arange(8 * 16 * 16, dtype=np.uint16).reshape(8, 16, 16)
+    data = da.from_array(raw, chunks=(4, 8, 8))
+    out = str(tmp_path / f"inherit_v{zarr_format}.zarr")
+
+    store_ome_zarr(
+        data,
+        out,
+        n_levels=1,
+        overwrite=True,
+        zarr_format=zarr_format,
+        io_backend="zarr",
+        # chunks intentionally omitted -> inherit from the source array.
+    )
+
+    group = open_group(out, mode="r")
+    # 3D source expanded to 5D TCZYX: chunksize (4, 8, 8) -> (1, 1, 4, 8, 8).
+    assert tuple(int(c) for c in group["0"].chunks) == (1, 1, 4, 8, 8)
+
+
+@pytest.mark.parametrize("zarr_format", [2, 3])
+def test_store_ome_zarr_mask_uses_windowed_mode(tmp_path, zarr_format) -> None:
+    from xarray_multiscale.reducers import windowed_mode
+
+    raw = (np.arange(4 * 8 * 8) % 2).astype(np.uint8).reshape(4, 8, 8)
+    mask = da.from_array(raw, chunks=(4, 8, 8))
+    out = str(tmp_path / f"mask_v{zarr_format}.zarr")
+
+    store_ome_zarr(
+        mask,
+        out,
+        n_levels=2,
+        voxel_size=(1.0, 1.0, 1.0),
+        origin=(0, 0, 0, 0, 0),
+        overwrite=True,
+        zarr_format=zarr_format,
+        io_backend="zarr",
+        reducer=windowed_mode,
+        write_empty_chunks=False,
+        chunks=(1, 1, 4, 8, 8),
+    )
+
+    group = open_group(out, mode="r")
+    multiscale = _multiscales(group, zarr_format)
+    assert multiscale["type"] == "windowed_mode"
+    assert "1" in group
+
+
+@pytest.mark.parametrize("zarr_format", [2, 3])
+def test_store_ome_zarr_tensorstore_skips_empty_chunks(tmp_path, zarr_format) -> None:
+    """The tensorstore backend honors write_empty_chunks=False (sparse output).
+
+    Regression guard for removing the old workaround that forced the zarr backend
+    for sparse writes; requires zarr-io's tensorstore backend to map
+    write_empty_chunks -> store_data_equal_to_fill_value.
+    """
+    pytest.importorskip("tensorstore")
+    # All-zeros volume: every chunk equals the default (0) fill value.
+    data = da.from_array(np.zeros((8, 16, 16), dtype=np.uint16), chunks=(4, 8, 8))
+    out = str(tmp_path / f"sparse_v{zarr_format}.zarr")
+
+    store_ome_zarr(
+        data,
+        out,
+        n_levels=1,
+        overwrite=True,
+        zarr_format=zarr_format,
+        io_backend="tensorstore",
+        write_empty_chunks=False,
+        chunks=(1, 1, 4, 8, 8),
+    )
+
+    # No chunk data files written for level 0 -- only metadata.
+    metadata_names = {"zarr.json", ".zarray", ".zattrs", ".zgroup"}
+    chunk_files = [
+        p
+        for p in (Path(out) / "0").rglob("*")
+        if p.is_file() and p.name not in metadata_names
+    ]
+    assert chunk_files == []
+
+    # Still reads back as the fill value.
+    group = open_group(out, mode="r")
+    level0 = read_zarr_array(group, component="0", io_backend="zarr").squeeze().compute()
+    np.testing.assert_array_equal(
+        level0.astype(np.uint16), np.zeros((8, 16, 16), dtype=np.uint16)
+    )
+
+
+def test_store_ome_zarr_clamps_levels(tmp_path) -> None:
+    data = da.from_array(np.ones((4, 4, 4), dtype=np.uint16), chunks=(4, 4, 4))
+    out = str(tmp_path / "tiny.zarr")
+
+    store_ome_zarr(
+        data,
+        out,
+        n_levels=10,  # far more than a 4x4x4 volume supports
+        overwrite=True,
+        zarr_format=3,
+        io_backend="zarr",
+        chunks=(1, 1, 4, 4, 4),
+    )
+
+    group = open_group(out, mode="r")
+    # (4,4,4) -> level 1 (2,2,2); xarray-multiscale stops there (2 levels total).
+    assert "0" in group
+    assert "1" in group
+    assert "2" not in group
+
+
+def test_store_ome_zarr_skips_existing_when_not_overwrite(tmp_path) -> None:
+    data = da.from_array(np.zeros((4, 4, 4), dtype=np.uint16), chunks=(4, 4, 4))
+    out = str(tmp_path / "existing.zarr")
+    store_ome_zarr(
+        data, out, n_levels=1, overwrite=True, zarr_format=3, io_backend="zarr"
+    )
+    # Second call without overwrite must be a no-op (does not raise).
+    store_ome_zarr(
+        data, out, n_levels=1, overwrite=False, zarr_format=3, io_backend="zarr"
+    )
+    assert "0" in open_group(out, mode="r")
+
+
+@pytest.mark.parametrize(
+    "zarr_format, attr_key",
+    [(3, "ome"), (2, "multiscales")],
+)
+def test_parse_ome_zarr_transformations_handles_both_layouts(
+    tmp_path, zarr_format, attr_key
+) -> None:
+    group = open_group(
+        str(tmp_path / f"meta_v{zarr_format}.zarr"),
+        mode="w",
+        zarr_format=zarr_format,
+    )
+    block = [
+        {
+            "datasets": [
+                {
+                    "path": "0",
+                    "coordinateTransformations": [
+                        {"type": "scale", "scale": [1, 1, 1, 1, 1]},
+                        {"type": "translation", "translation": [0, 0, 5, 6, 7]},
+                    ],
+                }
+            ]
+        }
+    ]
+    if attr_key == "ome":
+        group.attrs["ome"] = {"version": "0.5", "multiscales": block}
+    else:
+        group.attrs["multiscales"] = block
+
+    transforms = parse_ome_zarr_transformations(group, "0")
+    assert transforms["scale"] == [1, 1, 1, 1, 1]
+    assert transforms["translation"] == [0, 0, 5, 6, 7]
+
+
+def test_corrected_reducer_default_is_median_rank() -> None:
+    """Sanity check: the corrected/probability default reducer is rank=-2."""
+    from exaspim_flatfield_correction.utils.zarr_utils import DEFAULT_REDUCER
+    from xarray_multiscale.reducers import windowed_rank
+
+    assert isinstance(DEFAULT_REDUCER, partial)
+    assert DEFAULT_REDUCER.func is windowed_rank
+    assert DEFAULT_REDUCER.keywords == {"rank": -2}

--- a/tests/test_zarr_utils.py
+++ b/tests/test_zarr_utils.py
@@ -163,6 +163,118 @@ def test_store_ome_zarr_tensorstore_skips_empty_chunks(tmp_path, zarr_format) ->
     )
 
 
+def test_store_ome_zarr_v3_sharding(tmp_path) -> None:
+    """A tuple ``output_shards`` packs inner chunks into shards (Zarr v3)."""
+    raw = np.arange(8 * 16 * 16, dtype=np.uint8).reshape(8, 16, 16)
+    data = da.from_array(raw, chunks=(8, 16, 16))
+    out = str(tmp_path / "sharded.zarr")
+
+    store_ome_zarr(
+        data,
+        out,
+        n_levels=2,
+        overwrite=True,
+        zarr_format=3,
+        io_backend="zarr",
+        chunks=(1, 1, 4, 4, 4),
+        output_shards=(1, 1, 8, 8, 8),
+    )
+
+    level0 = open_group(out, mode="r")["0"]
+    chunks = tuple(int(c) for c in level0.chunks)
+    shards = tuple(int(s) for s in level0.shards)
+    assert chunks == (1, 1, 4, 4, 4)
+    assert shards == (1, 1, 8, 8, 8)
+    # Zarr v3 invariant: the shard is a whole multiple of the inner chunk.
+    assert all(s % c == 0 for s, c in zip(shards, chunks))
+
+    group = open_group(out, mode="r")
+    back = read_zarr_array(group, component="0", io_backend="zarr").squeeze().compute()
+    np.testing.assert_array_equal(back.astype(np.uint8), raw)
+
+
+def test_store_ome_zarr_v3_sharding_dense_tensorstore(tmp_path) -> None:
+    """Dense output shards correctly via the tensorstore backend (Zarr v3).
+
+    Covers the corrected-output path: write_empty_chunks=True (dense), the default
+    tensorstore backend, and an explicit shard tuple.
+    """
+    pytest.importorskip("tensorstore")
+    raw = np.arange(8 * 16 * 16, dtype=np.uint16).reshape(8, 16, 16)
+    data = da.from_array(raw, chunks=(4, 8, 8))
+    out = str(tmp_path / "sharded_dense_ts.zarr")
+
+    store_ome_zarr(
+        data,
+        out,
+        n_levels=2,
+        overwrite=True,
+        zarr_format=3,
+        io_backend="tensorstore",
+        write_empty_chunks=True,
+        chunks=(1, 1, 4, 8, 8),
+        output_shards=(1, 1, 8, 16, 16),
+    )
+
+    level0 = open_group(out, mode="r")["0"]
+    chunks = tuple(int(c) for c in level0.chunks)
+    shards = tuple(int(s) for s in level0.shards)
+    assert chunks == (1, 1, 4, 8, 8)
+    assert shards == (1, 1, 8, 16, 16)
+    assert all(s % c == 0 for s, c in zip(shards, chunks))
+
+    group = open_group(out, mode="r")
+    back = read_zarr_array(group, component="0", io_backend="zarr").squeeze().compute()
+    np.testing.assert_array_equal(back.astype(np.uint16), raw)
+
+
+def test_store_ome_zarr_shard_snaps_to_chunk_multiple(tmp_path) -> None:
+    """A shard that is not a clean multiple of the chunk is snapped to one."""
+    raw = np.zeros((20, 20, 20), dtype=np.uint8)
+    data = da.from_array(raw, chunks=(20, 20, 20))
+    out = str(tmp_path / "snap.zarr")
+
+    store_ome_zarr(
+        data,
+        out,
+        n_levels=1,
+        overwrite=True,
+        zarr_format=3,
+        io_backend="zarr",
+        chunks=(1, 1, 5, 5, 5),
+        # 16 is not a multiple of 5 -> round(16/5)=3 -> 15.
+        output_shards=(1, 1, 16, 16, 16),
+    )
+
+    level0 = open_group(out, mode="r")["0"]
+    assert tuple(int(s) for s in level0.shards) == (1, 1, 15, 15, 15)
+
+
+def test_store_ome_zarr_shard_larger_than_shape(tmp_path) -> None:
+    """A shard larger than the array shape is accepted (single partial shard)."""
+    raw = (np.arange(4 * 4 * 4) % 2).astype(np.uint8).reshape(4, 4, 4)
+    data = da.from_array(raw, chunks=(4, 4, 4))
+    out = str(tmp_path / "big_shard.zarr")
+
+    store_ome_zarr(
+        data,
+        out,
+        n_levels=1,
+        overwrite=True,
+        zarr_format=3,
+        io_backend="zarr",
+        chunks=(1, 1, 4, 4, 4),
+        output_shards=(1, 1, 1024, 1024, 1024),
+    )
+
+    level0 = open_group(out, mode="r")["0"]
+    # Snapped to a multiple of the (shape-clamped) chunk, still >> the shape.
+    assert tuple(int(s) for s in level0.shards) == (1, 1, 1024, 1024, 1024)
+    group = open_group(out, mode="r")
+    back = read_zarr_array(group, component="0", io_backend="zarr").squeeze().compute()
+    np.testing.assert_array_equal(back.astype(np.uint8), raw)
+
+
 def test_store_ome_zarr_clamps_levels(tmp_path) -> None:
     data = da.from_array(np.ones((4, 4, 4), dtype=np.uint16), chunks=(4, 4, 4))
     out = str(tmp_path / "tiny.zarr")


### PR DESCRIPTION
## Summary

This branch migrates the exaSPIM flatfield correction pipeline from Zarr v2 to **Zarr v3**, introduces a **TensorStore-based I/O backend**, and adds **sharding** for the mask, probability, and corrected output volumes to dramatically reduce the number of S3 objects. It also replaces the `aind-data-transfer` / `kerchunk` dependency stack with the lighter-weight `zarr-io` and `zarr-multiscale` libraries, and expands the typed `PipelineConfig` to expose I/O concurrency, sharding, and output-format controls.

Version bumped `0.1.3` → **`0.2.0`** (minor bump signaling breaking changes under 0.x semver).

## Major features

- **Zarr v3 output.** Artifacts (mask and probability volumes) are now always written as Zarr v3. The corrected dataset's format is configurable via `output_zarr_format` (`"match"` | `"2"` | `"3"`, default `"match"`).
- **TensorStore I/O backend.** New `io_backend` config option (`"tensorstore"` | `"zarr"`, default `"tensorstore"`) selecting the backend used to store arrays. The zarr backend is used automatically where empty-chunk writes are required.
- **Sharding for large volumes.** Configurable ZYX shard sizes pack many inner chunks into single shard objects (fewer S3 objects):
  - `mask_shard_size` (default `1024³`)
  - `probability_shard_size` (default `512³`, smaller because the volume is float32 / full-res)
  - `corrected_shard_size` (default `512³`, applied only for v3 output)
  - Each snaps to a whole multiple of the array's inner chunk; set to `null` to disable.
- **Per-worker I/O concurrency controls.** New `io_concurrency` config block maps 1:1 to `zarr_io.config.IOConcurrencyConfig` (zarr async/threading limits, TensorStore data-copy / file-IO / S3 / HTTP request limits).
- **Chunk-aligned block writes.** `max_chunks_per_block` (default `32768`) bounds how many chunks are written per `dask.compute`, keeping memory bounded when storing very large arrays.
- **Faster mask handling.** Mask is written at full resolution only (no multiscale) using a fast integer upsampling method (`_integer_upsample`), and empty chunks are written explicitly.
- **Expanded test coverage.** New/extended tests for config validation (`test_config.py`), output format (`test_output_format.py`), zarr utilities (`test_zarr_utils.py`), fitting, and background estimation — ~690 lines of new tests.

## Breaking changes

- **Output is now Zarr v3.** Mask and probability volumes are always v3; the corrected volume defaults to matching the input but can be v3. Downstream consumers must use a Zarr-v3-capable reader.
- **Python requirement raised `>=3.11` → `>=3.12`.**
- **Dependency stack overhauled** (`setup.cfg`):
  - `zarr` `2.18.7` → `3.2.1`
  - **Removed:** `aind-data-transfer[imaging]`, `kerchunk`
  - **Added:** `tensorstore==0.1.84`, `zarr-io` (git), `zarr-multiscale` (git), `xarray`, `xarray-multiscale==1.2.0`, `aind-data-schema==2.6.0`, `scikit-image`, `fsspec`
  - Bumped: `s3fs` → `2025.12.0`, `boto3[crt]` → `1.41.5`; `bokeh` capped `<3.9`
- **Public API changes** in `utils/zarr_utils.py`:
  - `initialize_zarr_group()` renamed to `ensure_group()`
  - `parse_ome_zarr_transformations()` removed
- **`code/run` no longer sources conda / activates the `correction` environment.**

## Non-breaking notes

- All new `PipelineConfig` fields have defaults, and no existing config fields were removed, so **existing config JSON files remain valid**. The `--config` CLI interface is unchanged.
- `PipelineConfig` uses `extra="forbid"`; config files containing unknown keys will be rejected.

## Test plan

- [x] `pytest tests/` passes
- [x] End-to-end run producing Zarr v3 output verified against a downstream reader
- [x] S3 object counts confirmed reduced with sharding enabled
