### PR TITLE
Feat: performance improvements

### DIFF
--- a/code/exaspim_flatfield_correction/__init__.py
+++ b/code/exaspim_flatfield_correction/__init__.py
@@ -1,3 +1,3 @@
 """Top-level package for exaspim flatfield correction."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/code/exaspim_flatfield_correction/fitting.py
+++ b/code/exaspim_flatfield_correction/fitting.py
@@ -226,27 +226,6 @@ def apply_axis_corrections(
     """
     corrected = full_res
     if global_med != 0 and np.isfinite(global_med):
-        fit_x = axis_fits.get("x")
-        if fit_x is not None:
-            correction_x = fit_x.reshape(1, 1, -1)
-            corrected = da.where(
-                mask_upscaled, corrected / correction_x, corrected
-            )
-
-        fit_y = axis_fits.get("y")
-        if fit_y is not None:
-            correction_y = fit_y.reshape(1, -1, 1)
-            corrected = da.where(
-                mask_upscaled, corrected / correction_y, corrected
-            )
-
-        fit_z = axis_fits.get("z")
-        if fit_z is not None:
-            correction_z = fit_z.reshape(-1, 1, 1)
-            corrected = da.where(
-                mask_upscaled, corrected / correction_z, corrected
-            )
-
         ratio = global_factor / global_med
         if ratio_limits is not None:
             clamped_ratio = float(
@@ -266,7 +245,24 @@ def apply_axis_corrections(
             global_med,
             ratio,
         )
-        corrected = da.where(mask_upscaled, corrected * ratio, corrected)
+
+        # Fold the per-axis curves and the global ratio into a single scaled
+        # volume applied with one da.where, instead of one masked division per
+        # axis plus a masked ratio multiply (each a full-volume pass). The
+        # reciprocal of each tiny 1D curve is taken up front (in float32 so the
+        # full-resolution graph is never promoted to float64) to trade the
+        # broadcast divisions for multiplications.
+        axis_reshapes = (("x", (1, 1, -1)), ("y", (1, -1, 1)), ("z", (-1, 1, 1)))
+        scaled = corrected
+        for axis_label, reshape in axis_reshapes:
+            fit = axis_fits.get(axis_label)
+            if fit is not None:
+                inv_fit = np.reciprocal(np.asarray(fit, dtype=np.float32))
+                scaled = scaled * inv_fit.reshape(reshape)
+        if ratio != 1.0:
+            scaled = scaled * ratio
+        if scaled is not corrected:
+            corrected = da.where(mask_upscaled, scaled, corrected)
         corrected = da.clip(corrected, 0, clip_max)
     else:
         _LOGGER.warning(

--- a/code/exaspim_flatfield_correction/fitting.py
+++ b/code/exaspim_flatfield_correction/fitting.py
@@ -91,7 +91,9 @@ def generate_axis_fit(
     fitted = rescale_spline(x, profile_np, new_width, smoothing=smoothing)
     if limits is not None:
         fitted = np.clip(fitted, limits[0], limits[1])
-    return fitted
+    # splev returns float64; cast so dividing the float32 volume by the curve
+    # does not promote the whole full-resolution graph to float64.
+    return np.asarray(fitted, dtype=np.float32)
 
 
 def _is_noop_limits(limits: "tuple[float, float] | None") -> bool:

--- a/code/exaspim_flatfield_correction/fitting.py
+++ b/code/exaspim_flatfield_correction/fitting.py
@@ -94,6 +94,12 @@ def generate_axis_fit(
     return fitted
 
 
+def _is_noop_limits(limits: "tuple[float, float] | None") -> bool:
+    """Limits of (1.0, 1.0) clamp the fitted curve to all-ones, making the
+    correction a no-op."""
+    return limits is not None and limits[0] == 1.0 and limits[1] == 1.0
+
+
 def compute_axis_fits(
     volume: "np.ndarray | da.Array",
     mask: "np.ndarray | da.Array",
@@ -127,7 +133,9 @@ def compute_axis_fits(
         Smoothing factor applied when resampling the correction profiles.
     limits_x, limits_y, limits_z : tuple of float or None, default=None
         Optional clamp bounds applied to the resampled profiles along each
-        axis.
+        axis. Limits of ``(1.0, 1.0)`` disable the correction for that axis:
+        its profile and fit are skipped entirely and the axis is omitted
+        from the returned mapping.
     weights : numpy.ndarray or None, optional
         Optional weighting array used for percentile calculations.
 
@@ -142,6 +150,19 @@ def compute_axis_fits(
         ("y", 1, full_shape[1], limits_y),
         ("z", 0, full_shape[0], limits_z),
     )
+
+    for axis_label, _, _, limits in axis_specs:
+        if _is_noop_limits(limits):
+            _LOGGER.info(
+                "Skipping correction for axis %s: limits %s clamp the fit to 1.0",
+                axis_label,
+                limits,
+            )
+    axis_specs = tuple(
+        spec for spec in axis_specs if not _is_noop_limits(spec[3])
+    )
+    if not axis_specs:
+        return {}
 
     axis_indices = [axis_idx for _, axis_idx, _, _ in axis_specs]
     profiles = masked_axis_profile(

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -354,6 +354,38 @@ def cleanup_background_cache(cache_path: Path | None) -> None:
         shutil.rmtree(cache_path, ignore_errors=True)
 
 
+def _fitting_cache_dir(results_dir: str) -> Path:
+    """Local scratch directory for fitting-stage array caches."""
+
+    return Path(results_dir) / "dask-temp" / "fitting-cache"
+
+
+def _low_res_cache_path(results_dir: str, tile_name: str) -> Path:
+    """Cache location for a tile's background-subtracted fitting volume."""
+
+    return (
+        _fitting_cache_dir(results_dir)
+        / f"{_safe_dask_name(tile_name)}_low_res.zarr"
+    )
+
+
+def _cache_dask_array(
+    arr: da.Array, cache_path: Path, *, name: str
+) -> da.Array:
+    """Stream a dask array to a local Zarr cache and reopen it lazily.
+
+    Stands in for ``persist()`` so downstream ``compute()`` calls re-read the
+    array from local disk instead of recomputing its source graph, without
+    pinning the volume in worker memory.
+    """
+
+    if cache_path.exists():
+        shutil.rmtree(cache_path)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    da.to_zarr(arr, str(cache_path), overwrite=True)
+    return da.from_zarr(str(cache_path), name=name)
+
+
 def flatfield_reference(full_res: da.Array, flatfield_path: str) -> da.Array:
     """Apply reference flatfield correction using a precomputed image.
 
@@ -582,7 +614,18 @@ def _create_mask_artifacts(
         tile_name,
         chunks=mask_chunks,
     ).astype(bool)
+    # Cache the combined mask on local disk: it is reused across tiles and
+    # evaluated by both the global percentile and the axis profiles, so the
+    # lazy ``low_res != 0`` term would otherwise re-evaluate the tile volume
+    # on every use, while persist() would pin it in worker memory. main()
+    # removes the cache after all tiles are processed.
     initial_mask = initial_mask & (low_res != 0)
+    initial_mask = _cache_dask_array(
+        initial_mask,
+        _fitting_cache_dir(results_dir)
+        / f"{_safe_dask_name(tile_name)}_mask.zarr",
+        name=f"mask-cache-{_safe_dask_name(tile_name)}-{uuid.uuid4().hex}",
+    )
 
     probability_volume: da.Array | None = None
     if config.enable_gmm_refinement:
@@ -716,6 +759,20 @@ def flatfield_fitting(
             chunks=low_res.chunksize[1:],
         ),
     )
+    # Cache the fitting-resolution volume on local disk and read it back. It
+    # feeds several independent compute() calls below (mask artifacts, global
+    # percentile, profile smoothing), each of which would otherwise re-read
+    # the tile from storage and re-subtract the background. A disk cache
+    # (rather than persist()) keeps worker memory free for the mask upscaling
+    # stage; process_tile removes it once the tile is finished.
+    if results_dir is not None:
+        low_res = _cache_dask_array(
+            low_res,
+            _low_res_cache_path(results_dir, tile_name),
+            name=(
+                f"lowres-cache-{_safe_dask_name(tile_name)}-{uuid.uuid4().hex}"
+            ),
+        )
 
     if mask_artifacts is None:
         mask_artifacts = _create_mask_artifacts(
@@ -1167,6 +1224,12 @@ def process_tile(
             raise
         finally:
             cleanup_background_cache(background_cache_path)
+            # Remove this tile's fitting-volume cache; the shared mask cache
+            # lives until all tiles are processed (removed in main()).
+            shutil.rmtree(
+                _low_res_cache_path(results_dir, tile_name),
+                ignore_errors=True,
+            )
 
     return mask_artifacts
 
@@ -1318,23 +1381,30 @@ def main() -> None:
                 ", ".join(sorted(median_summary)),
             )
 
-    for tile_path in args.tile_paths:
-        mask_artifacts = process_tile(
-            tile_path,
-            args=args,
-            method=args.method,
-            res=args.res,
-            binned_channel=args.binned_channel,
-            binned_res=binned_res,
-            results_dir=results_dir,
-            out_path=args.output,
-            out_mask_path=out_mask_path,
-            out_probability_path=out_probability_path,
-            data_process=data_process,
-            fitting_config=fitting_config,
-            median_summary=median_summary,
-            mask_artifacts=mask_artifacts,
-            output_format=output_format,
+    try:
+        for tile_path in args.tile_paths:
+            mask_artifacts = process_tile(
+                tile_path,
+                args=args,
+                method=args.method,
+                res=args.res,
+                binned_channel=args.binned_channel,
+                binned_res=binned_res,
+                results_dir=results_dir,
+                out_path=args.output,
+                out_mask_path=out_mask_path,
+                out_probability_path=out_probability_path,
+                data_process=data_process,
+                fitting_config=fitting_config,
+                median_summary=median_summary,
+                mask_artifacts=mask_artifacts,
+                output_format=output_format,
+            )
+    finally:
+        # Remove local scratch caches (the shared fitting mask plus any
+        # strays) so they are not uploaded with the artifacts below.
+        shutil.rmtree(
+            Path(results_dir) / "dask-temp", ignore_errors=True
         )
 
     if artifacts_destination:

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -552,7 +552,7 @@ def _create_mask_artifacts(
     low_res: da.Array,
     z: zarr.Group,
     fitting_res: str,
-    mask_dir: str,
+    initial_mask: np.ndarray,
     tile_name: str,
     results_dir: str,
     config: FittingConfig,
@@ -575,8 +575,9 @@ def _create_mask_artifacts(
         Zarr hierarchy that contains the tile data.
     fitting_res : str
         Resolution key within ``z`` from which the mask is derived.
-    mask_dir : str
-        Directory containing raw mask files.
+    initial_mask : numpy.ndarray
+        Raw tile mask loaded from disk (see
+        :func:`~exaspim_flatfield_correction.utils.utils.load_mask_from_dir`).
     tile_name : str
         Identifier of the tile driving mask generation.
     results_dir : str
@@ -599,11 +600,6 @@ def _create_mask_artifacts(
     """
     _LOGGER.info("Creating mask artifacts using tile %s", tile_name)
     mask_chunks = array_chunks(low_res)
-    try:
-        initial_mask = load_mask_from_dir(mask_dir, tile_name)
-    except FileNotFoundError as e:
-        _LOGGER.warning(f"Mask does not exist for tile {tile_name}. Skipping correction.")
-        return None
     initial_mask = _preprocess_mask(
         binary_fill_holes(
             size_filter(
@@ -759,6 +755,19 @@ def flatfield_fitting(
             chunks=low_res.chunksize[1:],
         ),
     )
+    initial_mask: np.ndarray | None = None
+    if mask_artifacts is None:
+        # Load the tile mask before the cache write below: a tile without a
+        # mask skips correction entirely and must not pay the full-volume
+        # compute and disk write the cache costs.
+        try:
+            initial_mask = load_mask_from_dir(mask_dir, tile_name)
+        except FileNotFoundError:
+            _LOGGER.warning(
+                f"Mask does not exist for tile {tile_name}. Skipping correction."
+            )
+            return full_res, None, None
+
     # Cache the fitting-resolution volume on local disk and read it back. It
     # feeds several independent compute() calls below (mask artifacts, global
     # percentile, profile smoothing), each of which would otherwise re-read
@@ -779,7 +788,7 @@ def flatfield_fitting(
             low_res=low_res,
             z=z,
             fitting_res=fitting_res,
-            mask_dir=mask_dir,
+            initial_mask=initial_mask,
             tile_name=tile_name,
             results_dir=results_dir,
             config=config,

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -1401,8 +1401,16 @@ def main() -> None:
                 output_format=output_format,
             )
     finally:
-        # Remove local scratch caches (the shared fitting mask plus any
-        # strays) so they are not uploaded with the artifacts below.
+        # dask-temp is also the cluster's temporary-directory (worker scratch
+        # and spill space, see create_dask_client), so shut the workers down
+        # before deleting it; otherwise live workers lose their spill files
+        # and can recreate the directory in time for the artifact upload
+        # below. Removing the tree drops the local scratch caches (the shared
+        # fitting mask plus any strays) so they are not uploaded.
+        try:
+            client.shutdown()
+        except Exception:
+            _LOGGER.exception("Failed to shut down Dask client")
         shutil.rmtree(
             Path(results_dir) / "dask-temp", ignore_errors=True
         )

--- a/code/exaspim_flatfield_correction/utils/utils.py
+++ b/code/exaspim_flatfield_correction/utils/utils.py
@@ -579,10 +579,13 @@ def weighted_percentile(
     else:
         hist_weights = mask.astype(np.float32)
 
-    data_min = int(data.min().compute())
-    data_max = int(data.max().compute())
+    # Compute both extrema in one pass; separate .compute() calls would each
+    # re-execute the full upstream graph (storage read, background subtraction).
+    data_min, data_max = da.compute(data.min(), data.max())
     if not np.isfinite(data_min) or not np.isfinite(data_max):
         raise ValueError("Encountered non-finite values while computing percentile range.")
+    data_min = int(data_min)
+    data_max = int(data_max)
     if data_min == data_max:
         return float(data_min)
 

--- a/environment/postInstall
+++ b/environment/postInstall
@@ -2,7 +2,7 @@
 set -euo pipefail
 git clone https://github.com/AllenNeuralDynamics/exaspim-flatfield-correction.git
 cd exaspim-flatfield-correction
-git checkout b0bc597dd34135a969777d164f81f73cdaa12f41
+git checkout e7ca908731ec3cb2e3f26d4c82c172e61ceb6b41
 pip install .
 
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -6,7 +6,11 @@ import dask.array as da
 import numpy as np
 import pytest
 
-from exaspim_flatfield_correction.fitting import calc_percentile_weight
+from exaspim_flatfield_correction.fitting import (
+    apply_axis_corrections,
+    calc_percentile_weight,
+    compute_axis_fits,
+)
 
 
 @pytest.mark.parametrize("smooth_sigma", [0.0, 3.0])
@@ -52,3 +56,87 @@ def test_calc_percentile_weight_degenerate_is_float32() -> None:
 
     assert weights.dtype == np.float32
     assert weights.compute().dtype == np.float32
+
+
+def _synthetic_volume_and_mask() -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(42)
+    volume = (rng.random((8, 10, 12)) * 1000 + 100).astype(np.float32)
+    mask = np.ones_like(volume, dtype=bool)
+    return volume, mask
+
+
+def test_compute_axis_fits_skips_noop_limits() -> None:
+    """An axis whose limits are (1.0, 1.0) is omitted from the fits."""
+    volume, mask = _synthetic_volume_and_mask()
+
+    fits = compute_axis_fits(
+        volume,
+        mask,
+        full_shape=(16, 20, 24),
+        limits_x=(0.5, 5.0),
+        limits_y=(1.0, 1.0),
+        limits_z=(0.5, 1.0),
+    )
+
+    assert set(fits) == {"x", "z"}
+    assert fits["x"].size == 24
+    assert fits["z"].size == 16
+
+
+def test_compute_axis_fits_all_noop_returns_empty() -> None:
+    """All axes disabled via (1.0, 1.0) limits yields an empty mapping."""
+    volume, mask = _synthetic_volume_and_mask()
+
+    fits = compute_axis_fits(
+        volume,
+        mask,
+        full_shape=(16, 20, 24),
+        limits_x=(1.0, 1.0),
+        limits_y=(1.0, 1.0),
+        limits_z=(1.0, 1.0),
+    )
+
+    assert fits == {}
+
+
+def test_compute_axis_fits_keeps_constant_non_unit_limits() -> None:
+    """Limits like (0.5, 0.5) are a constant correction, not a no-op."""
+    volume, mask = _synthetic_volume_and_mask()
+
+    fits = compute_axis_fits(
+        volume,
+        mask,
+        full_shape=(16, 20, 24),
+        limits_x=(0.5, 0.5),
+        limits_y=(1.0, 1.0),
+        limits_z=None,
+    )
+
+    assert set(fits) == {"x", "z"}
+    np.testing.assert_array_equal(fits["x"], np.full(24, 0.5, np.float32))
+
+
+def test_apply_axis_corrections_omitted_axis_matches_all_ones_fit() -> None:
+    """Omitting an axis from axis_fits is equivalent to an all-ones fit."""
+    rng = np.random.default_rng(7)
+    shape = (8, 10, 12)
+    full_res = da.from_array(
+        (rng.random(shape) * 1000).astype(np.float32), chunks=shape
+    )
+    mask = da.from_array(np.ones(shape, dtype=bool), chunks=shape)
+    fit_x = np.linspace(0.8, 1.2, shape[2]).astype(np.float32)
+
+    kwargs = dict(global_factor=500.0, global_med=400.0)
+    partial = apply_axis_corrections(full_res, mask, {"x": fit_x}, **kwargs)
+    explicit = apply_axis_corrections(
+        full_res,
+        mask,
+        {
+            "x": fit_x,
+            "y": np.ones(shape[1], np.float32),
+            "z": np.ones(shape[0], np.float32),
+        },
+        **kwargs,
+    )
+
+    np.testing.assert_array_equal(partial.compute(), explicit.compute())

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -116,6 +116,71 @@ def test_compute_axis_fits_keeps_constant_non_unit_limits() -> None:
     np.testing.assert_array_equal(fits["x"], np.full(24, 0.5, np.float32))
 
 
+def test_compute_axis_fits_returns_float32_curves() -> None:
+    """Curves must be float32 so they never promote the volume to float64."""
+    volume, mask = _synthetic_volume_and_mask()
+
+    fits = compute_axis_fits(volume, mask, full_shape=(16, 20, 24))
+
+    assert set(fits) == {"x", "y", "z"}
+    for fit in fits.values():
+        assert fit.dtype == np.float32
+
+
+def test_apply_axis_corrections_stays_float32_with_float64_fits() -> None:
+    """Even float64 curves must not promote the corrected volume."""
+    shape = (8, 10, 12)
+    full_res = da.ones(shape, dtype=np.float32, chunks=shape)
+    mask = da.from_array(np.ones(shape, dtype=bool), chunks=shape)
+    fits = {
+        "x": np.linspace(0.8, 1.2, shape[2]),  # float64
+        "y": np.linspace(0.9, 1.1, shape[1]),  # float64
+    }
+
+    corrected = apply_axis_corrections(
+        full_res, mask, fits, global_factor=500.0, global_med=400.0
+    )
+
+    assert corrected.dtype == np.float32
+    assert corrected.compute().dtype == np.float32
+
+
+def test_apply_axis_corrections_values_and_mask_respected() -> None:
+    """Masked voxels get full * ratio / (fx*fy*fz); unmasked stay untouched."""
+    rng = np.random.default_rng(3)
+    shape = (6, 8, 10)
+    data = (rng.random(shape) * 1000).astype(np.float32)
+    mask_np = np.zeros(shape, dtype=bool)
+    mask_np[:, :4, :] = True
+    full_res = da.from_array(data, chunks=shape)
+    mask = da.from_array(mask_np, chunks=shape)
+    fit_x = np.linspace(0.8, 1.2, shape[2]).astype(np.float32)
+    fit_y = np.linspace(0.9, 1.1, shape[1]).astype(np.float32)
+    fit_z = np.linspace(0.7, 1.3, shape[0]).astype(np.float32)
+    global_factor, global_med = 500.0, 400.0
+
+    corrected = apply_axis_corrections(
+        full_res,
+        mask,
+        {"x": fit_x, "y": fit_y, "z": fit_z},
+        global_factor=global_factor,
+        global_med=global_med,
+    ).compute()
+
+    ratio = global_factor / global_med
+    expected = (
+        data
+        * ratio
+        / fit_z.reshape(-1, 1, 1)
+        / fit_y.reshape(1, -1, 1)
+        / fit_x.reshape(1, 1, -1)
+    )
+    expected = np.where(mask_np, expected, data)
+    expected = np.clip(expected, 0, 2**16 - 1)
+    np.testing.assert_allclose(corrected, expected, rtol=1e-5)
+    np.testing.assert_array_equal(corrected[~mask_np], data[~mask_np])
+
+
 def test_apply_axis_corrections_omitted_axis_matches_all_ones_fit() -> None:
     """Omitting an axis from axis_fits is equivalent to an all-ones fit."""
     rng = np.random.default_rng(7)

--- a/tests/test_pipeline_cache.py
+++ b/tests/test_pipeline_cache.py
@@ -1,0 +1,71 @@
+"""Tests for the local disk caches used by the fitting pipeline stage."""
+
+from __future__ import annotations
+
+import dask.array as da
+import numpy as np
+
+from exaspim_flatfield_correction.pipeline import (
+    _cache_dask_array,
+    _fitting_cache_dir,
+    _low_res_cache_path,
+)
+
+
+def test_cache_dask_array_roundtrip_float32(tmp_path) -> None:
+    rng = np.random.default_rng(0)
+    data = (rng.random((8, 10, 12)) * 1000).astype(np.float32)
+    arr = da.from_array(data, chunks=(4, 5, 12))
+    cache_path = tmp_path / "low_res.zarr"
+
+    cached = _cache_dask_array(arr, cache_path, name="lowres-cache-test")
+
+    assert cache_path.exists()
+    assert cached.dtype == np.float32
+    assert cached.chunks == arr.chunks
+    np.testing.assert_array_equal(cached.compute(), data)
+
+
+def test_cache_dask_array_roundtrip_bool_and_overwrite(tmp_path) -> None:
+    cache_path = tmp_path / "mask.zarr"
+    first = da.from_array(np.zeros((4, 6), dtype=bool), chunks=(2, 6))
+    _cache_dask_array(first, cache_path, name="mask-cache-a")
+
+    mask = np.zeros((4, 6), dtype=bool)
+    mask[:, :3] = True
+    cached = _cache_dask_array(
+        da.from_array(mask, chunks=(2, 6)), cache_path, name="mask-cache-b"
+    )
+
+    assert cached.dtype == bool
+    np.testing.assert_array_equal(cached.compute(), mask)
+
+
+def test_cache_deletion_does_not_affect_independent_graphs(tmp_path) -> None:
+    """Downstream arrays that never reference the cache survive its removal."""
+    import shutil
+
+    data = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+    cached = _cache_dask_array(
+        da.from_array(data, chunks=(1, 3, 4)),
+        tmp_path / "tmp.zarr",
+        name="cache-tmp",
+    )
+    derived_np = (cached * 2).compute()  # materialized while cache exists
+    independent = da.from_array(data, chunks=(1, 3, 4)) + 1
+
+    shutil.rmtree(tmp_path / "tmp.zarr")
+
+    np.testing.assert_array_equal(independent.compute(), data + 1)
+    np.testing.assert_array_equal(derived_np, data * 2)
+
+
+def test_cache_paths_are_safe_and_scoped(tmp_path) -> None:
+    results_dir = str(tmp_path)
+    path = _low_res_cache_path(results_dir, "tile_x_0000_y_0001_z_0000_ch_488")
+
+    assert _fitting_cache_dir(results_dir) in path.parents
+    assert str(path).startswith(str(tmp_path / "dask-temp" / "fitting-cache"))
+    # tile names with unsafe characters are sanitized
+    weird = _low_res_cache_path(results_dir, "tile with/slash")
+    assert "/" not in weird.name.replace(".zarr", "")


### PR DESCRIPTION
### Summary

A set of performance optimizations to the fitting stage of the flatfield correction pipeline. These reduce redundant full-volume Dask computation, avoid unnecessary `float64` promotion, and skip work that has no effect on the output. Behavior is unchanged; the same corrected volumes are produced with less compute and I/O.

### Changes

**Avoid `float64` dtype promotion (`fitting.py`)**
- `generate_axis_fit` now casts the `splev` output back to `float32`. Previously the `float64` curve promoted the entire full-resolution graph to `float64` when the `float32` volume was divided by it.

**Fold per-axis corrections into a single scaled volume (`fitting.py`)**
- `apply_axis_corrections` previously ran one masked division per axis plus a masked ratio multiply — each a separate full-volume pass. These are now folded into a single scaled volume applied with one `da.where`. The reciprocal of each 1D curve is taken up front (in `float32`), trading broadcast divisions for multiplications.

**Skip no-op axis corrections (`fitting.py`)**
- Limits of `(1.0, 1.0)` clamp a fit to all-ones, making that axis's correction a no-op. `compute_axis_fits` now detects this, skips the profile and fit for that axis entirely, and omits it from the returned mapping (logging the skip).

**Compute min/max in one pass (`utils.py`)**
- `weighted_percentile` now computes both extrema with a single `da.compute(data.min(), data.max())` instead of two separate `.compute()` calls that each re-executed the full upstream graph (storage read + background subtraction).

**Cache intermediate Dask arrays to local disk (`pipeline.py`)**
- New `_cache_dask_array` helper streams a Dask array to a local Zarr cache and reopens it lazily — a stand-in for `persist()` that keeps the array off worker memory.
- The fitting-resolution volume and the combined mask are cached, since each feeds several independent `compute()` calls (mask artifacts, global percentile, profile smoothing) that would otherwise re-read the tile and re-subtract the background every time.
- Per-tile caches are removed in `process_tile`; the shared mask cache and the `dask-temp` tree are cleaned up in `main()`.

**Skip caching for tiles without a mask (`pipeline.py`)**
- The tile mask is now loaded *before* the cache write. A tile with no mask skips correction entirely and no longer pays for a full-volume compute and disk write it doesn't need.

**Shut down the Dask client before deleting scratch space (`pipeline.py`)**
- `main()`'s tile loop is wrapped in `try/finally` that shuts down the client before removing `dask-temp`. Since `dask-temp` is also the cluster's worker scratch/spill directory, deleting it while workers are live could lose spill files and let workers recreate the directory in time for the artifact upload.

**Housekeeping**
- Version bump `0.2.0` → `0.2.1` and updated the pinned commit hash in `environment/postInstall`.

### Tests
- Extended `tests/test_fitting.py` (no-op axis skipping, `float32` output, single-`da.where` folding).
- Added `tests/test_pipeline_cache.py` covering the local Zarr caching behavior.
