### PR TITLE
Fix probability volume construction

### DIFF
--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -116,10 +116,16 @@ def safe_performance_report(filename: str):
 
 @dataclass
 class MaskArtifacts:
-    """Container for cached mask artifacts reused within the pipeline."""
+    """Container for the reusable foreground mask shared across a tile's channels.
+
+    Only the foreground mask is cached here: it describes the tile's physical
+    geometry and is therefore channel-agnostic. The probability weights, by
+    contrast, are intensity-derived and computed per channel (see
+    :func:`_create_probability_volume`), so they are intentionally not stored on
+    this container.
+    """
 
     mask_low_res: da.Array
-    probability_volume: da.Array | None = None
 
 
 def _save_local_zarr(
@@ -550,31 +556,20 @@ def _preprocess_mask(
 
 def _create_mask_artifacts(
     low_res: da.Array,
-    z: zarr.Group,
-    fitting_res: str,
     initial_mask: np.ndarray,
     tile_name: str,
     results_dir: str,
-    config: FittingConfig,
-    bkg_slice_indices: np.ndarray,
-    out_probability_path: str,
-    overwrite: bool,
-    output_zarr_format: int = 2,
-    io_backend: IOBackendName | ArrayIOBackend = "tensorstore",
-    corrected_rank: int = -2,
-    max_chunks_per_block: int | None = 16384,
-    probability_shards: OutputShards = "none",
 ) -> MaskArtifacts:
-    """Generate mask artifacts and optional probability volumes for a tile.
+    """Generate the reusable foreground mask for a tile.
+
+    The mask describes the tile's physical geometry and is therefore shared
+    across the tile's channels. The intensity-derived probability weights are
+    produced separately, per channel, by :func:`_create_probability_volume`.
 
     Parameters
     ----------
     low_res : dask.array.Array
         Low-resolution stack used for mask inference.
-    z : zarr.Group
-        Zarr hierarchy that contains the tile data.
-    fitting_res : str
-        Resolution key within ``z`` from which the mask is derived.
     initial_mask : numpy.ndarray
         Raw tile mask loaded from disk (see
         :func:`~exaspim_flatfield_correction.utils.utils.load_mask_from_dir`).
@@ -582,15 +577,6 @@ def _create_mask_artifacts(
         Identifier of the tile driving mask generation.
     results_dir : str
         Destination directory for persisted mask artifacts.
-    config : FittingConfig
-        Configuration controlling mask refinement and thresholds.
-    bkg_slice_indices : numpy.ndarray
-        Indices of background-dominant slices used when estimating background
-        statistics for the probability volume.
-    out_probability_path : str
-        Root path where probability volumes are stored.
-    overwrite : bool
-        Whether existing outputs may be replaced.
 
     Returns
     -------
@@ -623,62 +609,110 @@ def _create_mask_artifacts(
         name=f"mask-cache-{_safe_dask_name(tile_name)}-{uuid.uuid4().hex}",
     )
 
-    probability_volume: da.Array | None = None
-    if config.enable_gmm_refinement:
-        slice_indices = np.asarray(bkg_slice_indices, dtype=np.int64)
-        bg_reference = da.take(low_res, slice_indices, axis=0).compute()
+    return MaskArtifacts(mask_low_res=initial_mask)
 
-        _LOGGER.info(
-            "Computing percentile-based probability weights (low=%.1f, high=%.1f, eps=%.3f)",
-            config.probability_bg_low_percentile,
-            config.probability_bg_high_percentile,
-            config.probability_ramp_eps,
-        )
 
-        probability_volume = calc_percentile_weight(
-            low_res,
-            bg_reference,
-            low_percentile=config.probability_bg_low_percentile,
-            high_percentile=config.probability_bg_high_percentile,
-            eps=config.probability_ramp_eps,
-            smooth_sigma=config.probability_smooth_sigma,
-            start_frac=config.probability_ramp_start_frac,
-            nu=config.probability_ramp_nu,
-        ).astype(np.float32)
+def _create_probability_volume(
+    low_res: da.Array,
+    z: zarr.Group,
+    fitting_res: str,
+    tile_name: str,
+    out_probability_path: str,
+    config: FittingConfig,
+    bkg_slice_indices: np.ndarray,
+    overwrite: bool,
+    io_backend: IOBackendName | ArrayIOBackend = "tensorstore",
+    corrected_rank: int = -2,
+    max_chunks_per_block: int | None = 16384,
+    probability_shards: OutputShards = "none",
+) -> da.Array | None:
+    """Compute, persist, and reload this channel's probability volume.
 
-        probability_path = out_probability_path.rstrip("/") + f"/{tile_name}"
-        probability_transformations = parse_ome_zarr_transformations(
-            z, fitting_res
-        )
-        probability_scale = probability_transformations["scale"]
-        probability_translation = probability_transformations["translation"]
+    Unlike the foreground mask, which is shared across a tile's channels, the
+    probability weights are derived from the channel's own background-subtracted
+    ``low_res`` data. They are therefore recomputed and written for every tile
+    (including channels that reuse the cached mask) rather than reused, so each
+    channel gets its own ``probability/<tile>`` output.
 
-        _LOGGER.info("Storing probability volume at %s", probability_path)
-        store_ome_zarr(
-            probability_volume,
-            probability_path,
-            5,
-            tuple(probability_scale[-3:]),
-            tuple(probability_translation),
-            overwrite=overwrite,
-            # Always Zarr v3 so the sparse, highly-compressed probability volume
-            # can be sharded (many tiny chunks -> one shard object on S3).
-            zarr_format=3,
-            io_backend=io_backend,
-            reducer=partial(windowed_rank, rank=corrected_rank),
-            write_empty_chunks=True,
-            max_chunks_per_block=max_chunks_per_block,
-            output_shards=probability_shards,
-        )
-        # Do not materialize into memory until needed
-        probability_volume = read_zarr_array(
-            probability_path, component="0", io_backend=io_backend
-        ).squeeze()
+    Parameters
+    ----------
+    low_res : dask.array.Array
+        Background-subtracted low-resolution stack for this channel.
+    z : zarr.Group
+        Zarr hierarchy that contains the tile data.
+    fitting_res : str
+        Resolution key within ``z`` used for the probability transformations.
+    tile_name : str
+        Identifier of the channel/tile being processed.
+    out_probability_path : str
+        Root path where probability volumes are stored.
+    config : FittingConfig
+        Configuration controlling the percentile-weight computation.
+    bkg_slice_indices : numpy.ndarray
+        Indices of background-dominant slices used to build the background
+        reference for the probability computation.
+    overwrite : bool
+        Whether existing outputs may be replaced.
 
-    return MaskArtifacts(
-        mask_low_res=initial_mask,
-        probability_volume=probability_volume,
+    Returns
+    -------
+    dask.array.Array or None
+        The reloaded probability volume, or ``None`` when GMM refinement is
+        disabled.
+
+    """
+    if not config.enable_gmm_refinement:
+        return None
+
+    slice_indices = np.asarray(bkg_slice_indices, dtype=np.int64)
+    bg_reference = da.take(low_res, slice_indices, axis=0).compute()
+
+    _LOGGER.info(
+        "Computing percentile-based probability weights (low=%.1f, high=%.1f, eps=%.3f)",
+        config.probability_bg_low_percentile,
+        config.probability_bg_high_percentile,
+        config.probability_ramp_eps,
     )
+
+    probability_volume = calc_percentile_weight(
+        low_res,
+        bg_reference,
+        low_percentile=config.probability_bg_low_percentile,
+        high_percentile=config.probability_bg_high_percentile,
+        eps=config.probability_ramp_eps,
+        smooth_sigma=config.probability_smooth_sigma,
+        start_frac=config.probability_ramp_start_frac,
+        nu=config.probability_ramp_nu,
+    ).astype(np.float32)
+
+    probability_path = out_probability_path.rstrip("/") + f"/{tile_name}"
+    probability_transformations = parse_ome_zarr_transformations(
+        z, fitting_res
+    )
+    probability_scale = probability_transformations["scale"]
+    probability_translation = probability_transformations["translation"]
+
+    _LOGGER.info("Storing probability volume at %s", probability_path)
+    store_ome_zarr(
+        probability_volume,
+        probability_path,
+        5,
+        tuple(probability_scale[-3:]),
+        tuple(probability_translation),
+        overwrite=overwrite,
+        # Always Zarr v3 so the sparse, highly-compressed probability volume
+        # can be sharded (many tiny chunks -> one shard object on S3).
+        zarr_format=3,
+        io_backend=io_backend,
+        reducer=partial(windowed_rank, rank=corrected_rank),
+        write_empty_chunks=True,
+        max_chunks_per_block=max_chunks_per_block,
+        output_shards=probability_shards,
+    )
+    # Do not materialize into memory until needed
+    return read_zarr_array(
+        probability_path, component="0", io_backend=io_backend
+    ).squeeze()
 
 
 def flatfield_fitting(
@@ -786,20 +820,9 @@ def flatfield_fitting(
     if mask_artifacts is None:
         mask_artifacts = _create_mask_artifacts(
             low_res=low_res,
-            z=z,
-            fitting_res=fitting_res,
             initial_mask=initial_mask,
             tile_name=tile_name,
             results_dir=results_dir,
-            config=config,
-            bkg_slice_indices=bkg_slice_indices,
-            out_probability_path=out_probability_path,
-            overwrite=overwrite,
-            output_zarr_format=output_zarr_format,
-            io_backend=io_backend,
-            corrected_rank=corrected_rank,
-            max_chunks_per_block=max_chunks_per_block,
-            probability_shards=probability_shards,
         )
     else:
         _LOGGER.info(
@@ -860,7 +883,24 @@ def flatfield_fitting(
     profile_min_voxels = config.profile_min_voxels
     spline_smoothing = config.spline_smoothing
 
-    weights = mask_artifacts.probability_volume
+    # The foreground mask is shared across a tile's channels, but the
+    # probability weights are intensity-derived and must be computed and written
+    # per channel. Do this for every tile -- including channels that reuse the
+    # cached mask -- so each channel gets its own probability/<tile> output.
+    weights = _create_probability_volume(
+        low_res=low_res,
+        z=z,
+        fitting_res=fitting_res,
+        tile_name=tile_name,
+        out_probability_path=out_probability_path,
+        config=config,
+        bkg_slice_indices=bkg_slice_indices,
+        overwrite=overwrite,
+        io_backend=io_backend,
+        corrected_rank=corrected_rank,
+        max_chunks_per_block=max_chunks_per_block,
+        probability_shards=probability_shards,
+    )
 
     global_val = weighted_percentile(
         low_res.round().astype(np.uint16),

--- a/tests/test_probability_volume.py
+++ b/tests/test_probability_volume.py
@@ -1,0 +1,105 @@
+"""Tests for the per-channel probability volume write.
+
+The foreground mask is shared across a tile's channels, but the probability
+weights are intensity-derived and must be written for *every* tile, including
+channels that reuse the cached mask. These tests exercise
+``_create_probability_volume`` directly (the unit the fitting stage now calls
+per channel) using local ``tmp_path`` zarr stores, so they need neither
+tensorstore nor S3.
+"""
+
+from __future__ import annotations
+
+import dask.array as da
+import numpy as np
+
+from exaspim_flatfield_correction.config import FittingConfig
+from exaspim_flatfield_correction.pipeline import _create_probability_volume
+from exaspim_flatfield_correction.utils.zarr_utils import store_ome_zarr
+from zarr_io.arrays import open_group, read_zarr_array
+
+
+def _make_tile(path: str, raw: np.ndarray) -> None:
+    """Write a minimal input OME-Zarr tile (data + transforms) at ``path``."""
+    store_ome_zarr(
+        da.from_array(raw, chunks=raw.shape),
+        path,
+        n_levels=1,
+        voxel_size=(2.0, 0.5, 0.5),
+        origin=(0, 0, 0, 0, 0),
+        overwrite=True,
+        zarr_format=3,
+        io_backend="zarr",
+    )
+
+
+def _low_res(raw: np.ndarray) -> da.Array:
+    return da.from_array(raw.astype(np.float32), chunks=(2, *raw.shape[1:]))
+
+
+def _write_probability(tmp_path, tile_name, raw, config, prob_root):
+    """Build a tile group and write its probability volume via the pipeline."""
+    tile_path = str(tmp_path / f"{tile_name}.zarr")
+    _make_tile(tile_path, raw)
+    z = open_group(tile_path, mode="r")
+    return _create_probability_volume(
+        low_res=_low_res(raw),
+        z=z,
+        fitting_res="0",
+        tile_name=tile_name,
+        out_probability_path=str(prob_root),
+        config=config,
+        bkg_slice_indices=np.array([0, 1], dtype=np.int64),
+        overwrite=True,
+        io_backend="zarr",
+    )
+
+
+def test_probability_volume_written_per_channel(tmp_path) -> None:
+    """Both channels of a tile get their own probability/<tile> output.
+
+    Regression for the bug where the probability volume was written only for
+    the first tile that computed the shared mask, so the second channel had a
+    mask but no probability volume.
+    """
+    config = FittingConfig(enable_gmm_refinement=True)
+    prob_root = tmp_path / "probability"
+
+    rng = np.random.default_rng(0)
+    raw_a = (rng.random((8, 16, 16)) * 1000).astype(np.float32)
+    raw_b = (rng.random((8, 16, 16)) * 1000).astype(np.float32)
+
+    weights_a = _write_probability(
+        tmp_path, "tile_000000_ch_488", raw_a, config, prob_root
+    )
+    weights_b = _write_probability(
+        tmp_path, "tile_000000_ch_561", raw_b, config, prob_root
+    )
+
+    # Each channel returns a materializable volume matching the input shape.
+    assert weights_a is not None and weights_b is not None
+    assert weights_a.squeeze().shape == raw_a.shape
+    assert weights_b.squeeze().shape == raw_b.shape
+
+    # Both channels are persisted independently under their own tile name.
+    for tile_name in ("tile_000000_ch_488", "tile_000000_ch_561"):
+        group = open_group(str(prob_root / tile_name), mode="r")
+        back = read_zarr_array(
+            group, component="0", io_backend="zarr"
+        ).squeeze().compute()
+        assert back.shape == raw_a.shape
+        assert back.dtype == np.float32
+
+
+def test_probability_volume_skipped_when_refinement_disabled(tmp_path) -> None:
+    """No probability volume is produced when GMM refinement is off."""
+    config = FittingConfig(enable_gmm_refinement=False)
+    prob_root = tmp_path / "probability"
+    raw = np.arange(8 * 16 * 16, dtype=np.float32).reshape(8, 16, 16)
+
+    weights = _write_probability(
+        tmp_path, "tile_000000_ch_488", raw, config, prob_root
+    )
+
+    assert weights is None
+    assert not (prob_root / "tile_000000_ch_488").exists()


### PR DESCRIPTION
This pull request refactors how mask and probability volume artifacts are managed in the flatfield correction pipeline, ensuring that the foreground mask is shared across channels while probability volumes are computed and persisted per channel. It also adds targeted tests to verify the correct behavior. The main improvements are a clearer separation of mask and probability volume logic, improved documentation, and regression tests to prevent previous bugs.

**Refactoring and Separation of Concerns:**
- Split the creation of mask artifacts and probability volumes into two functions: `_create_mask_artifacts` now only handles the reusable foreground mask, while the new `_create_probability_volume` function computes and persists the per-channel probability weights. [[1]](diffhunk://#diff-1a804196c3f8cbd9cba93008d23de6bfd207fa65df3e82abd6c0c2d464737aa9L553-L593) [[2]](diffhunk://#diff-1a804196c3f8cbd9cba93008d23de6bfd207fa65df3e82abd6c0c2d464737aa9L626-R666) [[3]](diffhunk://#diff-1a804196c3f8cbd9cba93008d23de6bfd207fa65df3e82abd6c0c2d464737aa9L674-L682)
- Updated the `MaskArtifacts` dataclass to only cache the foreground mask and improved its documentation to clarify its channel-agnostic nature.

**Pipeline Logic Updates:**
- Modified `flatfield_fitting` to always compute and persist the probability volume for each channel, even when the mask is reused, ensuring every channel has its own probability output. [[1]](diffhunk://#diff-1a804196c3f8cbd9cba93008d23de6bfd207fa65df3e82abd6c0c2d464737aa9L789-L802) [[2]](diffhunk://#diff-1a804196c3f8cbd9cba93008d23de6bfd207fa65df3e82abd6c0c2d464737aa9L863-R903)

**Testing Improvements:**
- Added `tests/test_probability_volume.py` with direct tests for `_create_probability_volume`, including regression tests to ensure probability volumes are written for every channel and skipped when refinement is disabled.