### PR TITLE
Feat: exclude background slices from fitting mask

### DIFF
--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -375,6 +375,15 @@ def _low_res_cache_path(results_dir: str, tile_name: str) -> Path:
     )
 
 
+def _filtered_mask_cache_path(results_dir: str, tile_name: str) -> Path:
+    """Cache location for a tile's background-filtered fitting mask."""
+
+    return (
+        _fitting_cache_dir(results_dir)
+        / f"{_safe_dask_name(tile_name)}_filtered_mask.zarr"
+    )
+
+
 def _cache_dask_array(
     arr: da.Array, cache_path: Path, *, name: str
 ) -> da.Array:
@@ -613,58 +622,57 @@ def _create_mask_artifacts(
 
 
 def _exclude_background_slices_from_mask(
-    mask: da.Array,
+    mask: np.ndarray,
     bkg_slice_indices: np.ndarray,
-) -> da.Array:
+) -> np.ndarray:
     """Remove background-estimation Z planes from a fitting mask.
 
     The background indices and ``mask`` are both expressed in the fitting
     resolution (resolution 0 for a binned channel and resolution 3 for an
-    unbinned channel).  The reusable mask artifact is deliberately left
-    unchanged: background slices are estimated per channel and may differ
-    between channels that share the same anatomical mask.
+    unbinned channel). The input is copied so the reusable mask artifact is
+    left unchanged: background slices are estimated per channel and may differ
+    between channels that share the same anatomical mask. Performing this
+    operation eagerly keeps the broadcast slice-selection operation out of the
+    Dask graph that is subsequently upscaled.
 
     Parameters
     ----------
-    mask : dask.array.Array
+    mask : numpy.ndarray
         Three-dimensional fitting mask in ``(z, y, x)`` order.
     bkg_slice_indices : numpy.ndarray
         Z indices selected for background estimation.
 
     Returns
     -------
-    dask.array.Array
+    numpy.ndarray
         Boolean mask with every selected background plane set to ``False``.
     """
-    if mask.ndim != 3:
+    mask_np = np.asarray(mask, dtype=bool)
+    if mask_np.ndim != 3:
         raise ValueError(
             "Fitting mask must be three-dimensional (z, y, x), "
-            f"received shape {mask.shape}"
+            f"received shape {mask_np.shape}"
         )
 
     slice_indices = np.asarray(bkg_slice_indices, dtype=np.int64).reshape(-1)
-    if slice_indices.size == 0:
-        return mask.astype(bool)
-
     invalid = slice_indices[
-        (slice_indices < 0) | (slice_indices >= mask.shape[0])
+        (slice_indices < 0) | (slice_indices >= mask_np.shape[0])
     ]
     if invalid.size:
         raise ValueError(
             "Background slice indices are outside the fitting mask Z range "
-            f"[0, {mask.shape[0]}): {np.unique(invalid).tolist()}"
+            f"[0, {mask_np.shape[0]}): {np.unique(invalid).tolist()}"
         )
 
     slice_indices = np.unique(slice_indices)
-    keep_z = np.ones(mask.shape[0], dtype=bool)
-    keep_z[slice_indices] = False
-    keep_z_da = da.from_array(keep_z, chunks=(mask.chunks[0],))
+    filtered_mask = mask_np.copy()
+    filtered_mask[slice_indices] = False
 
     _LOGGER.info(
         "Excluding %s background-estimation Z slices from the fitting mask",
         slice_indices.size,
     )
-    return mask.astype(bool) & keep_z_da[:, np.newaxis, np.newaxis]
+    return filtered_mask
 
 
 def _create_probability_volume(
@@ -887,10 +895,27 @@ def flatfield_fitting(
         _LOGGER.warning(f"mask_artifacts is None. Skipping correction for tile {tile_name}")
         return full_res, None, None
 
-    mask = _exclude_background_slices_from_mask(
-        mask_artifacts.mask_low_res,
+    mask_np = _exclude_background_slices_from_mask(
+        mask_artifacts.mask_low_res.compute(),
         bkg_slice_indices,
     )
+    mask_chunks = array_chunks(mask_artifacts.mask_low_res)
+    if results_dir is not None:
+        mask_cache_path = _filtered_mask_cache_path(results_dir, tile_name)
+        _save_local_zarr(str(mask_cache_path), mask_np, mask_chunks)
+        mask = da.from_zarr(
+            str(mask_cache_path),
+            name=(
+                f"filtered-mask-cache-{_safe_dask_name(tile_name)}-"
+                f"{uuid.uuid4().hex}"
+            ),
+        )
+    else:
+        # Preserve support for direct callers without a scratch directory.
+        # The production pipeline always supplies results_dir and uses the
+        # disk-backed branch above.
+        mask = da.from_array(mask_np, chunks=mask_chunks)
+    del mask_np
 
     if mask.shape == full_res.shape:
         _LOGGER.info("Mask already at full resolution, skipping upscaling.")
@@ -1331,10 +1356,15 @@ def process_tile(
             raise
         finally:
             cleanup_background_cache(background_cache_path)
-            # Remove this tile's fitting-volume cache; the shared mask cache
-            # lives until all tiles are processed (removed in main()).
+            # Remove this tile's fitting-volume and channel-specific filtered
+            # mask caches. The shared mask cache lives until all tiles are
+            # processed (removed in main()).
             shutil.rmtree(
                 _low_res_cache_path(results_dir, tile_name),
+                ignore_errors=True,
+            )
+            shutil.rmtree(
+                _filtered_mask_cache_path(results_dir, tile_name),
                 ignore_errors=True,
             )
 

--- a/code/exaspim_flatfield_correction/pipeline.py
+++ b/code/exaspim_flatfield_correction/pipeline.py
@@ -612,6 +612,61 @@ def _create_mask_artifacts(
     return MaskArtifacts(mask_low_res=initial_mask)
 
 
+def _exclude_background_slices_from_mask(
+    mask: da.Array,
+    bkg_slice_indices: np.ndarray,
+) -> da.Array:
+    """Remove background-estimation Z planes from a fitting mask.
+
+    The background indices and ``mask`` are both expressed in the fitting
+    resolution (resolution 0 for a binned channel and resolution 3 for an
+    unbinned channel).  The reusable mask artifact is deliberately left
+    unchanged: background slices are estimated per channel and may differ
+    between channels that share the same anatomical mask.
+
+    Parameters
+    ----------
+    mask : dask.array.Array
+        Three-dimensional fitting mask in ``(z, y, x)`` order.
+    bkg_slice_indices : numpy.ndarray
+        Z indices selected for background estimation.
+
+    Returns
+    -------
+    dask.array.Array
+        Boolean mask with every selected background plane set to ``False``.
+    """
+    if mask.ndim != 3:
+        raise ValueError(
+            "Fitting mask must be three-dimensional (z, y, x), "
+            f"received shape {mask.shape}"
+        )
+
+    slice_indices = np.asarray(bkg_slice_indices, dtype=np.int64).reshape(-1)
+    if slice_indices.size == 0:
+        return mask.astype(bool)
+
+    invalid = slice_indices[
+        (slice_indices < 0) | (slice_indices >= mask.shape[0])
+    ]
+    if invalid.size:
+        raise ValueError(
+            "Background slice indices are outside the fitting mask Z range "
+            f"[0, {mask.shape[0]}): {np.unique(invalid).tolist()}"
+        )
+
+    slice_indices = np.unique(slice_indices)
+    keep_z = np.ones(mask.shape[0], dtype=bool)
+    keep_z[slice_indices] = False
+    keep_z_da = da.from_array(keep_z, chunks=(mask.chunks[0],))
+
+    _LOGGER.info(
+        "Excluding %s background-estimation Z slices from the fitting mask",
+        slice_indices.size,
+    )
+    return mask.astype(bool) & keep_z_da[:, np.newaxis, np.newaxis]
+
+
 def _create_probability_volume(
     low_res: da.Array,
     z: zarr.Group,
@@ -832,7 +887,10 @@ def flatfield_fitting(
         _LOGGER.warning(f"mask_artifacts is None. Skipping correction for tile {tile_name}")
         return full_res, None, None
 
-    mask = mask_artifacts.mask_low_res
+    mask = _exclude_background_slices_from_mask(
+        mask_artifacts.mask_low_res,
+        bkg_slice_indices,
+    )
 
     if mask.shape == full_res.shape:
         _LOGGER.info("Mask already at full resolution, skipping upscaling.")

--- a/environment/postInstall
+++ b/environment/postInstall
@@ -2,7 +2,7 @@
 set -euo pipefail
 git clone https://github.com/AllenNeuralDynamics/exaspim-flatfield-correction.git
 cd exaspim-flatfield-correction
-git checkout c8a72c82cedbf34f90bd00d517307df3f1dade4d
+git checkout b71e63b43d0d8db78711fcf784c8fbbf60a5c8c2
 pip install .
 
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"

--- a/tests/test_fitting_mask.py
+++ b/tests/test_fitting_mask.py
@@ -1,0 +1,101 @@
+"""Tests for fitting-mask preparation and background-slice exclusion."""
+
+from __future__ import annotations
+
+import dask.array as da
+import numpy as np
+import zarr
+
+from exaspim_flatfield_correction import pipeline as pipeline_module
+from exaspim_flatfield_correction.config import FittingConfig
+from exaspim_flatfield_correction.pipeline import (
+    MaskArtifacts,
+    flatfield_fitting,
+)
+
+
+def test_flatfield_fitting_excludes_background_slices_before_statistics(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Global/profile statistics and the output mask omit background planes."""
+    shape = (5, 4, 3)
+    raw = np.full(shape, 20, dtype=np.uint16)
+    root = zarr.group(store=zarr.storage.MemoryStore(), zarr_format=3)
+    input_array = root.create_array(
+        "0", shape=shape, dtype=raw.dtype, chunks=(2, 4, 3)
+    )
+    input_array[:] = raw
+
+    full_res = da.from_array(raw.astype(np.float32), chunks=(2, 4, 3))
+    shared_mask = da.ones(shape, chunks=(2, 4, 3), dtype=bool)
+    background_indices = np.asarray([1, 4], dtype=np.int64)
+    expected_mask = np.ones(shape, dtype=bool)
+    expected_mask[background_indices] = False
+    observed_masks: dict[str, np.ndarray] = {}
+
+    monkeypatch.setattr(
+        pipeline_module,
+        "_create_probability_volume",
+        lambda **_: None,
+    )
+
+    def fake_weighted_percentile(data, mask, percentile, weights=None):
+        observed_masks["global"] = mask.compute()
+        return 10.0
+
+    def fake_compute_axis_fits(volume, mask, full_shape, **kwargs):
+        observed_masks["profiles"] = mask.compute()
+        return {}
+
+    def fake_apply_axis_corrections(
+        full_res,
+        mask_upscaled,
+        axis_fits,
+        **kwargs,
+    ):
+        observed_masks["output"] = mask_upscaled.compute()
+        return full_res
+
+    monkeypatch.setattr(
+        pipeline_module, "weighted_percentile", fake_weighted_percentile
+    )
+    monkeypatch.setattr(
+        pipeline_module, "compute_axis_fits", fake_compute_axis_fits
+    )
+    monkeypatch.setattr(
+        pipeline_module, "apply_axis_corrections", fake_apply_axis_corrections
+    )
+
+    corrected, axis_fits, returned_artifacts = flatfield_fitting(
+        full_res=full_res,
+        z=root,
+        is_binned_channel=True,
+        mask_dir=str(tmp_path),
+        tile_name="tile_ch_561.zarr",
+        out_mask_path=str(tmp_path / "mask"),
+        out_probability_path=str(tmp_path / "probability"),
+        coordinate_transformations={
+            "scale": (1.0, 1.0, 1.0, 1.0, 1.0),
+            "translation": (0.0, 0.0, 0.0, 0.0, 0.0),
+        },
+        overwrite=True,
+        config=FittingConfig(
+            enable_gmm_refinement=False,
+            gaussian_sigma=0,
+        ),
+        bkg=np.zeros(shape[1:], dtype=np.float32),
+        bkg_slice_indices=background_indices,
+        mask_artifacts=MaskArtifacts(mask_low_res=shared_mask),
+        io_backend="zarr",
+    )
+
+    assert corrected is full_res
+    assert axis_fits == {}
+    assert returned_artifacts is not None
+    np.testing.assert_array_equal(
+        returned_artifacts.mask_low_res.compute(), np.ones(shape, dtype=bool)
+    )
+    assert set(observed_masks) == {"global", "profiles", "output"}
+    for observed in observed_masks.values():
+        np.testing.assert_array_equal(observed, expected_mask)

--- a/tests/test_fitting_mask.py
+++ b/tests/test_fitting_mask.py
@@ -10,6 +10,7 @@ from exaspim_flatfield_correction import pipeline as pipeline_module
 from exaspim_flatfield_correction.config import FittingConfig
 from exaspim_flatfield_correction.pipeline import (
     MaskArtifacts,
+    _filtered_mask_cache_path,
     flatfield_fitting,
 )
 
@@ -19,20 +20,29 @@ def test_flatfield_fitting_excludes_background_slices_before_statistics(
     monkeypatch,
 ) -> None:
     """Global/profile statistics and the output mask omit background planes."""
-    shape = (5, 4, 3)
-    raw = np.full(shape, 20, dtype=np.uint16)
+    low_shape = (3, 4, 3)
+    full_shape = tuple(2 * size for size in low_shape)
+    raw = np.full(low_shape, 20, dtype=np.uint16)
     root = zarr.group(store=zarr.storage.MemoryStore(), zarr_format=3)
     input_array = root.create_array(
-        "0", shape=shape, dtype=raw.dtype, chunks=(2, 4, 3)
+        "3", shape=low_shape, dtype=raw.dtype, chunks=(2, 4, 3)
     )
     input_array[:] = raw
 
-    full_res = da.from_array(raw.astype(np.float32), chunks=(2, 4, 3))
-    shared_mask = da.ones(shape, chunks=(2, 4, 3), dtype=bool)
-    background_indices = np.asarray([1, 4], dtype=np.int64)
-    expected_mask = np.ones(shape, dtype=bool)
-    expected_mask[background_indices] = False
+    full_res = da.full(full_shape, 20, chunks=(2, 4, 3), dtype=np.float32)
+    shared_mask = da.ones(low_shape, chunks=(2, 4, 3), dtype=bool)
+    background_indices = np.asarray([1, 2], dtype=np.int64)
+    expected_low_res_mask = np.ones(low_shape, dtype=bool)
+    expected_low_res_mask[background_indices] = False
+    expected_full_res_mask = np.repeat(
+        np.repeat(
+            np.repeat(expected_low_res_mask, 2, axis=0), 2, axis=1
+        ),
+        2,
+        axis=2,
+    )
     observed_masks: dict[str, np.ndarray] = {}
+    observed_mask_names: dict[str, str] = {}
 
     monkeypatch.setattr(
         pipeline_module,
@@ -42,10 +52,12 @@ def test_flatfield_fitting_excludes_background_slices_before_statistics(
 
     def fake_weighted_percentile(data, mask, percentile, weights=None):
         observed_masks["global"] = mask.compute()
+        observed_mask_names["global"] = mask.name
         return 10.0
 
     def fake_compute_axis_fits(volume, mask, full_shape, **kwargs):
         observed_masks["profiles"] = mask.compute()
+        observed_mask_names["profiles"] = mask.name
         return {}
 
     def fake_apply_axis_corrections(
@@ -70,7 +82,7 @@ def test_flatfield_fitting_excludes_background_slices_before_statistics(
     corrected, axis_fits, returned_artifacts = flatfield_fitting(
         full_res=full_res,
         z=root,
-        is_binned_channel=True,
+        is_binned_channel=False,
         mask_dir=str(tmp_path),
         tile_name="tile_ch_561.zarr",
         out_mask_path=str(tmp_path / "mask"),
@@ -84,9 +96,10 @@ def test_flatfield_fitting_excludes_background_slices_before_statistics(
             enable_gmm_refinement=False,
             gaussian_sigma=0,
         ),
-        bkg=np.zeros(shape[1:], dtype=np.float32),
+        bkg=np.zeros(low_shape[1:], dtype=np.float32),
         bkg_slice_indices=background_indices,
         mask_artifacts=MaskArtifacts(mask_low_res=shared_mask),
+        results_dir=str(tmp_path),
         io_backend="zarr",
     )
 
@@ -94,8 +107,23 @@ def test_flatfield_fitting_excludes_background_slices_before_statistics(
     assert axis_fits == {}
     assert returned_artifacts is not None
     np.testing.assert_array_equal(
-        returned_artifacts.mask_low_res.compute(), np.ones(shape, dtype=bool)
+        returned_artifacts.mask_low_res.compute(),
+        np.ones(low_shape, dtype=bool),
     )
     assert set(observed_masks) == {"global", "profiles", "output"}
-    for observed in observed_masks.values():
-        np.testing.assert_array_equal(observed, expected_mask)
+    np.testing.assert_array_equal(
+        observed_masks["global"], expected_low_res_mask
+    )
+    np.testing.assert_array_equal(
+        observed_masks["profiles"], expected_low_res_mask
+    )
+    np.testing.assert_array_equal(
+        observed_masks["output"], expected_full_res_mask
+    )
+    assert all(
+        name.startswith("filtered-mask-cache-")
+        for name in observed_mask_names.values()
+    )
+    assert _filtered_mask_cache_path(
+        str(tmp_path), "tile_ch_561.zarr"
+    ).is_dir()

--- a/tests/test_pipeline_cache.py
+++ b/tests/test_pipeline_cache.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from exaspim_flatfield_correction.pipeline import (
     _cache_dask_array,
+    _exclude_background_slices_from_mask,
     _fitting_cache_dir,
     _low_res_cache_path,
 )
@@ -69,3 +70,47 @@ def test_cache_paths_are_safe_and_scoped(tmp_path) -> None:
     # tile names with unsafe characters are sanitized
     weird = _low_res_cache_path(results_dir, "tile with/slash")
     assert "/" not in weird.name.replace(".zarr", "")
+
+
+def test_exclude_background_slices_from_mask() -> None:
+    mask_np = np.ones((6, 4, 5), dtype=bool)
+    mask_np[4, 1:, 2:] = False
+    mask = da.from_array(mask_np, chunks=(2, 2, 5))
+
+    filtered = _exclude_background_slices_from_mask(
+        mask,
+        np.asarray([1, 3, 3], dtype=np.int64),
+    )
+    expected = mask_np.copy()
+    expected[[1, 3]] = False
+
+    assert filtered.dtype == bool
+    assert filtered.chunks == mask.chunks
+    np.testing.assert_array_equal(filtered.compute(), expected)
+
+
+def test_background_slice_exclusion_does_not_mutate_shared_mask() -> None:
+    mask_np = np.ones((4, 3, 2), dtype=bool)
+    shared = da.from_array(mask_np, chunks=(2, 3, 2))
+
+    first_channel = _exclude_background_slices_from_mask(
+        shared, np.asarray([0])
+    )
+    second_channel = _exclude_background_slices_from_mask(
+        shared, np.asarray([2])
+    )
+
+    np.testing.assert_array_equal(shared.compute(), mask_np)
+    assert not first_channel[0].compute().any()
+    assert first_channel[2].compute().all()
+    assert second_channel[0].compute().all()
+    assert not second_channel[2].compute().any()
+
+
+def test_exclude_background_slices_rejects_out_of_range_indices() -> None:
+    mask = da.ones((4, 3, 2), chunks=(2, 3, 2), dtype=bool)
+
+    with np.testing.assert_raises_regex(
+        ValueError, "outside the fitting mask Z range"
+    ):
+        _exclude_background_slices_from_mask(mask, np.asarray([-1, 4]))

--- a/tests/test_pipeline_cache.py
+++ b/tests/test_pipeline_cache.py
@@ -8,6 +8,7 @@ import numpy as np
 from exaspim_flatfield_correction.pipeline import (
     _cache_dask_array,
     _exclude_background_slices_from_mask,
+    _filtered_mask_cache_path,
     _fitting_cache_dir,
     _low_res_cache_path,
 )
@@ -70,47 +71,71 @@ def test_cache_paths_are_safe_and_scoped(tmp_path) -> None:
     # tile names with unsafe characters are sanitized
     weird = _low_res_cache_path(results_dir, "tile with/slash")
     assert "/" not in weird.name.replace(".zarr", "")
+    filtered_mask = _filtered_mask_cache_path(
+        results_dir, "tile with/slash"
+    )
+    assert _fitting_cache_dir(results_dir) in filtered_mask.parents
+    assert "/" not in filtered_mask.name.replace(".zarr", "")
 
 
 def test_exclude_background_slices_from_mask() -> None:
     mask_np = np.ones((6, 4, 5), dtype=bool)
     mask_np[4, 1:, 2:] = False
-    mask = da.from_array(mask_np, chunks=(2, 2, 5))
 
     filtered = _exclude_background_slices_from_mask(
-        mask,
+        mask_np,
         np.asarray([1, 3, 3], dtype=np.int64),
     )
     expected = mask_np.copy()
     expected[[1, 3]] = False
 
     assert filtered.dtype == bool
-    assert filtered.chunks == mask.chunks
-    np.testing.assert_array_equal(filtered.compute(), expected)
+    assert not np.shares_memory(filtered, mask_np)
+    np.testing.assert_array_equal(filtered, expected)
 
 
 def test_background_slice_exclusion_does_not_mutate_shared_mask() -> None:
     mask_np = np.ones((4, 3, 2), dtype=bool)
-    shared = da.from_array(mask_np, chunks=(2, 3, 2))
 
     first_channel = _exclude_background_slices_from_mask(
-        shared, np.asarray([0])
+        mask_np, np.asarray([0])
     )
     second_channel = _exclude_background_slices_from_mask(
-        shared, np.asarray([2])
+        mask_np, np.asarray([2])
     )
 
-    np.testing.assert_array_equal(shared.compute(), mask_np)
-    assert not first_channel[0].compute().any()
-    assert first_channel[2].compute().all()
-    assert second_channel[0].compute().all()
-    assert not second_channel[2].compute().any()
+    assert mask_np.all()
+    assert not first_channel[0].any()
+    assert first_channel[2].all()
+    assert second_channel[0].all()
+    assert not second_channel[2].any()
+
+
+def test_exclude_no_background_slices_returns_independent_mask() -> None:
+    mask = np.ones((2, 3, 4), dtype=np.uint8)
+
+    filtered = _exclude_background_slices_from_mask(
+        mask, np.asarray([], dtype=np.int64)
+    )
+
+    assert filtered.dtype == bool
+    assert not np.shares_memory(filtered, mask)
+    assert filtered.all()
 
 
 def test_exclude_background_slices_rejects_out_of_range_indices() -> None:
-    mask = da.ones((4, 3, 2), chunks=(2, 3, 2), dtype=bool)
+    mask = np.ones((4, 3, 2), dtype=bool)
 
     with np.testing.assert_raises_regex(
         ValueError, "outside the fitting mask Z range"
     ):
         _exclude_background_slices_from_mask(mask, np.asarray([-1, 4]))
+
+
+def test_exclude_background_slices_requires_3d_mask() -> None:
+    with np.testing.assert_raises_regex(
+        ValueError, "must be three-dimensional"
+    ):
+        _exclude_background_slices_from_mask(
+            np.ones((3, 4), dtype=bool), np.asarray([0])
+        )


### PR DESCRIPTION
This pull request introduces a new mechanism for excluding background-estimation Z slices from the fitting mask in the flatfield correction pipeline, ensuring that background planes are omitted from downstream statistics and correction steps. It adds a utility for caching these filtered masks, integrates the exclusion into the main fitting workflow, and provides comprehensive tests to verify correct behavior and cache management.